### PR TITLE
Reorganizar panel superior y rediseñar el gato virtual

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,60 +86,33 @@
         pointer-events: none;
       }
 
-      .device-header {
-        text-align: center;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        gap: 6px;
-        z-index: 1;
-      }
-
-      .device-logo {
-        font-family: "Press Start 2P", system-ui;
-        font-size: clamp(1.05rem, 1.8vw, 1.35rem);
-        letter-spacing: 0.12em;
-        text-transform: uppercase;
-        color: #ffeef8;
-        text-shadow: 0 5px 0 rgba(0, 0, 0, 0.15), 0 0 24px rgba(255, 255, 255, 0.45);
-      }
-
-      .device-lights {
-        display: flex;
-        gap: 10px;
-      }
-
-      .device-lights span {
-        width: 12px;
-        height: 12px;
-        border-radius: 50%;
-        background: rgba(255, 255, 255, 0.65);
-        box-shadow: 0 0 12px rgba(255, 255, 255, 0.9);
-        animation: twinkle 3.4s ease-in-out infinite;
-      }
-
-      .device-lights span:nth-child(2) {
-        animation-delay: 0.8s;
-      }
-
-      .device-lights span:nth-child(3) {
-        animation-delay: 1.6s;
-      }
-
-      .name-band {
+      .status-strip {
         width: 100%;
         display: flex;
         align-items: center;
-        justify-content: center;
-        flex-wrap: wrap;
-        gap: 12px;
-        padding: 12px 14px;
-        border-radius: 999px;
+        gap: 16px;
+        padding: 12px 16px;
+        border-radius: 22px;
         background: rgba(255, 255, 255, 0.45);
         border: 3px solid rgba(255, 255, 255, 0.65);
         box-shadow: inset 0 0 12px rgba(255, 255, 255, 0.35);
         font-weight: 600;
         color: var(--text-secondary);
+      }
+
+      .status-meta {
+        display: flex;
+        flex: 1;
+        align-items: center;
+        justify-content: space-between;
+        gap: 14px;
+        flex-wrap: wrap;
+      }
+
+      .info-chips {
+        display: inline-flex;
+        gap: 10px;
+        flex-wrap: wrap;
       }
 
       .name-field {
@@ -204,13 +177,12 @@
       }
 
       .day-switch {
-        align-self: flex-end;
         display: inline-flex;
         align-items: center;
         gap: 8px;
         border: none;
         border-radius: 999px;
-        padding: 6px 10px;
+        padding: 8px 12px 6px;
         font: inherit;
         font-size: 0.62rem;
         text-transform: uppercase;
@@ -219,6 +191,8 @@
         color: inherit;
         cursor: pointer;
         transition: transform 0.2s ease, box-shadow 0.2s ease;
+        white-space: nowrap;
+        flex-shrink: 0;
       }
 
       .day-switch:hover {
@@ -489,7 +463,7 @@
         grid-template-columns: repeat(auto-fit, minmax(48px, 1fr));
         gap: 18px;
         justify-items: center;
-        margin-top: 6px;
+        margin: 4px 0 0;
       }
 
       .device-button {
@@ -622,10 +596,6 @@
         background: rgba(6, 2, 30, 0.4);
       }
 
-      body[data-mode="night"] .device-logo {
-        color: #ffeefd;
-        text-shadow: 0 5px 0 rgba(0, 0, 0, 0.3), 0 0 22px rgba(138, 126, 255, 0.6);
-      }
 
       body[data-mode="night"] .log-window {
         background: rgba(24, 18, 61, 0.65);
@@ -718,17 +688,20 @@
           border-radius: 160px 160px 200px 200px;
         }
 
-        .device-header {
-          gap: 4px;
+        .status-strip {
+          gap: 12px;
+          padding: 10px 14px;
         }
 
-        .device-logo {
-          font-size: clamp(0.95rem, 4vw, 1.1rem);
-        }
-
-        .name-band {
+        .status-meta {
           gap: 10px;
-          justify-content: center;
+          flex-direction: column;
+          align-items: flex-start;
+          justify-content: flex-start;
+        }
+
+        .info-chips {
+          width: 100%;
         }
 
         .name-field {
@@ -752,7 +725,7 @@
 
         .day-switch {
           font-size: 0.55rem;
-          padding: 5px 9px;
+          padding: 6px 9px 5px;
         }
 
         .scene {
@@ -879,188 +852,202 @@
         }
       }
 
-      @keyframes twinkle {
-        0%,
-        100% {
-          opacity: 0.85;
-          transform: scale(1);
-        }
-        50% {
-          opacity: 0.35;
-          transform: scale(0.75);
-        }
-      }
     </style>
   </head>
   <body data-mode="day">
     <main class="device">
-      <header class="device-header">
-        <div class="device-logo">Catagotchi</div>
-        <div class="device-lights"><span></span><span></span><span></span></div>
-      </header>
-      <div class="name-band">
-        <label class="name-field" for="catName">
-          <span>Nombre</span>
-          <input id="catName" maxlength="16" placeholder="PIXEL" />
-        </label>
-        <div class="chip">Nivel <strong id="level-label">1</strong></div>
-        <div class="chip">Vet <strong id="vet-timer">--:--</strong></div>
-      </div>
       <section class="screen-section" aria-labelledby="panel-estado">
         <div class="screen" role="region" aria-live="polite">
-          <button class="day-switch" id="daySwitch" type="button" aria-label="Cambiar entorno">
-            <span id="dayEmoji">🌞</span>
-            <span id="dayLabel">Parque soleado</span>
-          </button>
+          <div class="status-strip">
+            <button class="day-switch" id="daySwitch" type="button" aria-label="Cambiar entorno">
+              <span id="dayEmoji">🌞</span>
+              <span id="dayLabel">Parque soleado</span>
+            </button>
+            <div class="status-meta">
+              <label class="name-field" for="catName">
+                <span>Nombre</span>
+                <input id="catName" maxlength="16" placeholder="PIXEL" />
+              </label>
+              <div class="info-chips">
+                <div class="chip">Nivel <strong id="level-label">1</strong></div>
+                <div class="chip">Vet <strong id="vet-timer">--:--</strong></div>
+              </div>
+            </div>
+          </div>
           <div class="scene" id="catScene">
             <div class="scene-floor"></div>
             <div class="cat-wanderer" id="catWanderer">
               <div class="cat-shadow"></div>
               <div class="cat" id="cat" data-mood="feliz">
-                <svg viewBox="0 0 260 260" role="img" aria-label="Gato virtual">
+                <svg viewBox="0 0 240 240" role="img" aria-label="Gato virtual">
                   <defs>
-                    <radialGradient id="furMain" cx="50%" cy="35%" r="65%">
-                      <stop offset="0%" stop-color="#ffeadd" />
-                      <stop offset="55%" stop-color="#f4bfa4" />
-                      <stop offset="100%" stop-color="#e2917a" />
+                    <radialGradient id="furMain" cx="50%" cy="30%" r="75%">
+                      <stop offset="0%" stop-color="#fff4fb" />
+                      <stop offset="60%" stop-color="#f9c2e3" />
+                      <stop offset="100%" stop-color="#ec8fc6" />
                     </radialGradient>
-                    <radialGradient id="bellyGradient" cx="50%" cy="35%" r="65%">
-                      <stop offset="0%" stop-color="#fff7f0" />
-                      <stop offset="100%" stop-color="#ffd7c0" />
+                    <radialGradient id="furBelly" cx="50%" cy="40%" r="75%">
+                      <stop offset="0%" stop-color="#fffdfc" />
+                      <stop offset="100%" stop-color="#ffe1f0" />
                     </radialGradient>
                     <linearGradient id="tailGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-                      <stop offset="0%" stop-color="#fdd1b8" />
-                      <stop offset="100%" stop-color="#e78f74" />
+                      <stop offset="0%" stop-color="#f6b3de" />
+                      <stop offset="100%" stop-color="#d76aa9" />
                     </linearGradient>
-                    <radialGradient id="earInner" cx="50%" cy="55%" r="60%">
-                      <stop offset="0%" stop-color="#ffd5e8" />
-                      <stop offset="100%" stop-color="#f49ac6" />
+                    <radialGradient id="earInner" cx="50%" cy="50%" r="70%">
+                      <stop offset="0%" stop-color="#ffd6ef" />
+                      <stop offset="100%" stop-color="#f79fd1" />
                     </radialGradient>
                     <radialGradient id="cheekGradient" cx="50%" cy="50%" r="50%">
-                      <stop offset="0%" stop-color="#ffb7c9" />
-                      <stop offset="100%" stop-color="#ff8fae" />
+                      <stop offset="0%" stop-color="#ffb1cb" />
+                      <stop offset="100%" stop-color="#ff80b4" />
                     </radialGradient>
+                    <linearGradient id="stripeGradient" x1="0%" y1="0%" x2="0%" y2="100%">
+                      <stop offset="0%" stop-color="rgba(209, 84, 152, 0.25)" />
+                      <stop offset="100%" stop-color="rgba(209, 84, 152, 0)" />
+                    </linearGradient>
                   </defs>
                   <g id="tail">
                     <path
-                      d="M188 186 C218 170 226 144 214 120 C206 104 188 96 172 104"
+                      d="M170 158 C202 150 212 122 198 98 C186 76 156 76 136 94"
                       fill="none"
                       stroke="url(#tailGradient)"
                       stroke-width="18"
                       stroke-linecap="round"
+                      stroke-linejoin="round"
                     />
                     <path
-                      d="M188 186 C202 188 214 182 220 170"
+                      d="M170 158 C190 160 204 148 208 132"
                       fill="none"
-                      stroke="#fcd0b8"
+                      stroke="rgba(255, 255, 255, 0.45)"
                       stroke-width="6"
                       stroke-linecap="round"
                     />
                   </g>
                   <g id="cat-body">
                     <path
-                      d="M88 166 C70 182 66 214 82 236 C98 258 128 268 156 258 C184 248 198 220 188 190 C180 162 156 150 132 150 C112 150 98 156 88 166 Z"
+                      d="M66 134 C44 158 50 198 86 214 C120 230 170 220 190 186 C204 162 198 124 172 106 C150 90 124 92 102 100 C86 106 74 118 66 134 Z"
                       fill="url(#furMain)"
-                      stroke="#d87f64"
+                      stroke="#cf6ba9"
                       stroke-width="4"
                       stroke-linejoin="round"
                     />
                     <path
-                      d="M116 174 C104 186 102 212 114 230 C128 250 160 242 166 212 C170 186 150 172 132 170 C126 170 120 170 116 174 Z"
-                      fill="url(#bellyGradient)"
-                      opacity="0.92"
+                      d="M94 152 C82 172 92 200 120 208 C150 216 174 198 176 170 C178 144 156 128 132 128 C116 128 102 136 94 152 Z"
+                      fill="url(#furBelly)"
+                      stroke="rgba(255, 255, 255, 0.4)"
+                      stroke-width="2"
                     />
                     <path
-                      d="M101 200 C108 220 122 228 132 228"
-                      stroke="rgba(255, 255, 255, 0.6)"
-                      stroke-width="6"
-                      stroke-linecap="round"
-                      opacity="0.8"
-                    />
-                    <ellipse cx="110" cy="236" rx="16" ry="10" fill="#f7c9ad" opacity="0.8" />
-                    <ellipse cx="150" cy="236" rx="16" ry="10" fill="#f7c9ad" opacity="0.8" />
-                    <path
-                      d="M92 188 C98 174 112 166 132 166 C152 166 168 174 174 188"
+                      d="M88 150 C100 134 118 126 132 126"
                       fill="none"
-                      stroke="rgba(255, 255, 255, 0.35)"
-                      stroke-width="6"
+                      stroke="url(#stripeGradient)"
+                      stroke-width="12"
                       stroke-linecap="round"
                     />
-                  </g>
-                  <g id="ears">
-                    <path d="M94 70 L66 28 Q100 16 120 50 Z" fill="#e2927b" />
-                    <path d="M94 70 L72 34 Q100 28 114 54 Z" fill="url(#earInner)" opacity="0.9" />
-                    <path d="M170 70 L198 28 Q164 16 144 50 Z" fill="#e2927b" />
-                    <path d="M170 70 L192 34 Q164 28 150 54 Z" fill="url(#earInner)" opacity="0.9" />
+                    <path
+                      d="M150 150 C164 140 170 122 168 110"
+                      fill="none"
+                      stroke="url(#stripeGradient)"
+                      stroke-width="10"
+                      stroke-linecap="round"
+                    />
                   </g>
                   <g id="head">
                     <path
-                      d="M70 122 C66 86 90 60 118 58 C126 36 150 36 162 58 C190 60 214 86 210 122 C206 160 178 186 140 186 C102 186 74 160 70 122 Z"
+                      d="M86 72 L66 40 L102 56 Z"
                       fill="url(#furMain)"
-                      stroke="#d87f64"
+                      stroke="#cf6ba9"
                       stroke-width="4"
                       stroke-linejoin="round"
                     />
                     <path
-                      d="M86 104 C92 86 108 74 128 74 C148 74 164 86 170 104"
-                      fill="none"
-                      stroke="rgba(255, 255, 255, 0.45)"
-                      stroke-width="8"
-                      stroke-linecap="round"
+                      d="M178 72 L198 40 L162 56 Z"
+                      fill="url(#furMain)"
+                      stroke="#cf6ba9"
+                      stroke-width="4"
+                      stroke-linejoin="round"
+                    />
+                    <path d="M86 72 L74 52 L100 62 Z" fill="url(#earInner)" opacity="0.75" />
+                    <path d="M178 72 L190 52 L164 62 Z" fill="url(#earInner)" opacity="0.75" />
+                    <path
+                      d="M74 124 C70 92 92 60 126 56 C162 52 194 78 194 116 C194 146 172 170 140 170 C108 170 84 150 74 124 Z"
+                      fill="url(#furMain)"
+                      stroke="#cf6ba9"
+                      stroke-width="4"
+                      stroke-linejoin="round"
                     />
                     <path
-                      d="M120 66 Q132 58 144 66"
-                      stroke="rgba(255, 255, 255, 0.65)"
+                      d="M120 74 C110 80 102 92 100 104"
+                      fill="none"
+                      stroke="rgba(207, 107, 169, 0.5)"
                       stroke-width="6"
                       stroke-linecap="round"
                     />
                     <path
-                      d="M92 142 Q110 158 132 158 Q154 158 172 142"
+                      d="M162 74 C172 80 180 92 182 106"
                       fill="none"
-                      stroke="rgba(255, 255, 255, 0.28)"
+                      stroke="rgba(207, 107, 169, 0.5)"
                       stroke-width="6"
                       stroke-linecap="round"
                     />
                   </g>
-                  <g id="face" fill="#27132f">
+                  <g id="face">
+                    <ellipse cx="116" cy="118" rx="16" ry="20" fill="#fff" opacity="0.85" />
+                    <ellipse cx="160" cy="118" rx="16" ry="20" fill="#fff" opacity="0.85" />
+                    <circle cx="116" cy="120" r="8" fill="#251431" />
+                    <circle cx="160" cy="120" r="8" fill="#251431" />
+                    <circle cx="112" cy="116" r="3" fill="#fff" opacity="0.7" />
+                    <circle cx="156" cy="116" r="3" fill="#fff" opacity="0.7" />
+                    <polygon points="130,122 122,130 130,136 138,130" fill="#f7a7c4" stroke="#cf6ba9" stroke-width="2" />
                     <path
-                      d="M124 150 Q132 158 140 150"
-                      stroke="#27132f"
-                      stroke-width="6"
-                      stroke-linecap="round"
+                      d="M130 136 Q130 144 122 148"
                       fill="none"
+                      stroke="#cf6ba9"
+                      stroke-width="4"
+                      stroke-linecap="round"
                     />
-                    <ellipse cx="110" cy="130" rx="14" ry="18" />
-                    <ellipse cx="154" cy="130" rx="14" ry="18" />
-                    <circle cx="110" cy="130" r="6" fill="#12081d" />
-                    <circle cx="154" cy="130" r="6" fill="#12081d" />
-                    <circle cx="104" cy="126" r="3" fill="#fff" opacity="0.6" />
-                    <circle cx="148" cy="126" r="3" fill="#fff" opacity="0.6" />
-                    <path d="M132 140 Q130 146 124 148" stroke="#f7a7ba" stroke-width="4" stroke-linecap="round" fill="none" />
-                    <path d="M132 140 Q134 146 140 148" stroke="#f7a7ba" stroke-width="4" stroke-linecap="round" fill="none" />
-                    <polygon points="128,138 132,130 136,138" fill="#f7a7ba" />
-                    <circle cx="100" cy="144" r="8" fill="url(#cheekGradient)" opacity="0.7" />
-                    <circle cx="164" cy="144" r="8" fill="url(#cheekGradient)" opacity="0.7" />
-                    <path d="M88 138 Q104 142 120 140" stroke="#27132f" stroke-width="3" stroke-linecap="round" fill="none" />
-                    <path d="M144 140 Q160 142 176 138" stroke="#27132f" stroke-width="3" stroke-linecap="round" fill="none" />
+                    <path
+                      d="M130 136 Q130 144 138 148"
+                      fill="none"
+                      stroke="#cf6ba9"
+                      stroke-width="4"
+                      stroke-linecap="round"
+                    />
+                    <circle cx="106" cy="134" r="8" fill="url(#cheekGradient)" opacity="0.7" />
+                    <circle cx="170" cy="134" r="8" fill="url(#cheekGradient)" opacity="0.7" />
+                    <path
+                      d="M96 124 Q110 128 122 126"
+                      fill="none"
+                      stroke="#532247"
+                      stroke-width="3"
+                      stroke-linecap="round"
+                    />
+                    <path
+                      d="M138 126 Q150 128 164 124"
+                      fill="none"
+                      stroke="#532247"
+                      stroke-width="3"
+                      stroke-linecap="round"
+                    />
+                    <path
+                      d="M94 136 Q112 140 130 138"
+                      fill="none"
+                      stroke="rgba(83, 34, 71, 0.5)"
+                      stroke-width="3"
+                      stroke-linecap="round"
+                    />
+                    <path
+                      d="M130 138 Q148 140 166 136"
+                      fill="none"
+                      stroke="rgba(83, 34, 71, 0.5)"
+                      stroke-width="3"
+                      stroke-linecap="round"
+                    />
                   </g>
-                  <path
-                    d="M106 120 C108 114 118 110 132 110 C146 110 156 114 158 120"
-                    fill="none"
-                    stroke="rgba(39, 19, 47, 0.35)"
-                    stroke-width="4"
-                    stroke-linecap="round"
-                  />
-                  <path
-                    d="M118 172 Q132 184 146 172"
-                    fill="none"
-                    stroke="rgba(214, 143, 116, 0.6)"
-                    stroke-width="5"
-                    stroke-linecap="round"
-                  />
                   <g id="accessory" opacity="0">
                     <path
-                      d="M106 206 C122 198 142 198 158 206 L152 220 C140 214 124 214 112 220 Z"
+                      d="M96 176 C118 170 142 170 164 176 L156 194 C140 188 120 188 104 194 Z"
                       fill="#6ee7ff"
                       stroke="#4aa5ff"
                       stroke-width="3"
@@ -1070,6 +1057,14 @@
                 </svg>
               </div>
             </div>
+          </div>
+          <div class="button-row">
+            <button class="device-button" data-action="feed" data-label="Comer" aria-label="Alimentar">🍣</button>
+            <button class="device-button" data-action="play" data-label="Jugar" aria-label="Jugar">🧶</button>
+            <button class="device-button" data-action="groom" data-label="Aseo" aria-label="Baño y cepillado">🛁</button>
+            <button class="device-button" data-action="nap" data-label="Dormir" aria-label="Siestita">😴</button>
+            <button class="device-button" data-action="vet" data-label="Vet" aria-label="Visita al veterinario">💉</button>
+            <button class="device-button" data-action="surprise" data-label="Sorp" aria-label="Sorpresa">🎁</button>
           </div>
           <div class="screen-hud">
             <div class="hud-top">
@@ -1123,14 +1118,6 @@
         <h2 class="log-title">Diario</h2>
         <div class="activity-log" id="log"></div>
       </section>
-      <div class="button-row">
-        <button class="device-button" data-action="feed" data-label="Comer" aria-label="Alimentar">🍣</button>
-        <button class="device-button" data-action="play" data-label="Jugar" aria-label="Jugar">🧶</button>
-        <button class="device-button" data-action="groom" data-label="Aseo" aria-label="Baño y cepillado">🛁</button>
-        <button class="device-button" data-action="nap" data-label="Dormir" aria-label="Siestita">😴</button>
-        <button class="device-button" data-action="vet" data-label="Vet" aria-label="Visita al veterinario">💉</button>
-        <button class="device-button" data-action="surprise" data-label="Sorp" aria-label="Sorpresa">🎁</button>
-      </div>
     </main>
 
     <div class="toast" id="toast" role="status" aria-live="polite">


### PR DESCRIPTION
## Summary
- integrar el selector de día con el nombre, nivel y temporizador en una sola franja superior dentro de la pantalla del juego
- mover los botones de acciones justo debajo de la escena principal y crear un nuevo arte del gato con una estética más suave

## Testing
- No tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cfdcbe5eac832ba7841ab0e605ad66