### PR TITLE
Actualizar el Catagotchi con HUD compacto y gato tuxedo

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,6 @@
         --progress-fill: linear-gradient(90deg, #ff9bc6 0%, #ffda85 100%);
         --progress-fill-cool: linear-gradient(90deg, #8bc6ff 0%, #74f2ff 100%);
         --progress-fill-fun: linear-gradient(90deg, #f996ff 0%, #ffa4d4 100%);
-        --progress-fill-health: linear-gradient(90deg, #7dffb5 0%, #52d5a4 100%);
         --text-primary: #53163c;
         --text-secondary: #a13a6f;
         --button-bg: #ffe5f3;
@@ -90,6 +89,8 @@
         width: 100%;
         display: flex;
         align-items: center;
+        justify-content: space-between;
+        flex-wrap: wrap;
         gap: 16px;
         padding: 12px 16px;
         border-radius: 22px;
@@ -100,27 +101,40 @@
         color: var(--text-secondary);
       }
 
-      .status-meta {
+      .identity {
         display: flex;
-        flex: 1;
         align-items: center;
-        justify-content: space-between;
-        gap: 14px;
-        flex-wrap: wrap;
+        gap: 12px;
+        flex: 1;
       }
 
-      .info-chips {
-        display: inline-flex;
-        gap: 10px;
-        flex-wrap: wrap;
+      .identity-avatar {
+        width: 48px;
+        height: 48px;
+        border-radius: 16px;
+        background: rgba(255, 255, 255, 0.85);
+        border: 2px solid rgba(255, 134, 201, 0.55);
+        display: grid;
+        place-items: center;
+        font-size: 1.8rem;
+        box-shadow: 0 6px 0 rgba(255, 118, 197, 0.35);
+        flex-shrink: 0;
+      }
+
+      .identity-meta {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        min-width: 0;
+        align-items: flex-start;
       }
 
       .name-field {
-        display: inline-flex;
-        align-items: center;
-        gap: 8px;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
         font-family: "Press Start 2P", system-ui;
-        font-size: 0.62rem;
+        font-size: 0.54rem;
         letter-spacing: 0.08em;
         text-transform: uppercase;
       }
@@ -132,7 +146,8 @@
         padding: 6px 8px 4px;
         font: inherit;
         color: var(--text-primary);
-        width: 120px;
+        width: 118px;
+        max-width: 100%;
         text-transform: uppercase;
       }
 
@@ -145,15 +160,16 @@
         outline-offset: 2px;
       }
 
-      .chip {
+      .level-pill {
+        align-self: flex-start;
         font-family: "Press Start 2P", system-ui;
-        font-size: 0.58rem;
+        font-size: 0.56rem;
         letter-spacing: 0.08em;
-        background: rgba(255, 255, 255, 0.75);
+        background: rgba(255, 255, 255, 0.78);
         color: var(--text-primary);
-        padding: 6px 10px 4px;
+        padding: 4px 9px 3px;
         border-radius: 999px;
-        border: 2px solid rgba(255, 118, 197, 0.5);
+        border: 2px solid rgba(255, 118, 197, 0.45);
         box-shadow: 0 4px 0 rgba(255, 118, 197, 0.35);
       }
 
@@ -356,7 +372,7 @@
 
       .stat-grid {
         display: grid;
-        grid-template-columns: repeat(2, 1fr);
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
         gap: 12px;
         font-size: 0.58rem;
       }
@@ -379,10 +395,6 @@
 
       .stat[data-theme="fun"] .progress-fill {
         background: var(--progress-fill-fun);
-      }
-
-      .stat[data-theme="health"] .progress-fill {
-        background: var(--progress-fill-health);
       }
 
       .stat-title {
@@ -693,29 +705,29 @@
           padding: 10px 14px;
         }
 
-        .status-meta {
+        .identity {
           gap: 10px;
-          flex-direction: column;
-          align-items: flex-start;
-          justify-content: flex-start;
         }
 
-        .info-chips {
-          width: 100%;
+        .identity-avatar {
+          width: 42px;
+          height: 42px;
+          border-radius: 14px;
+          font-size: 1.5rem;
         }
 
         .name-field {
-          font-size: 0.56rem;
+          font-size: 0.5rem;
         }
 
         .name-field input {
-          width: 110px;
+          width: 108px;
           padding: 5px 7px 4px;
         }
 
-        .chip {
+        .level-pill {
           font-size: 0.5rem;
-          padding: 5px 8px 4px;
+          padding: 4px 8px 3px;
         }
 
         .screen {
@@ -812,6 +824,12 @@
           width: 96px;
         }
 
+        .identity-avatar {
+          width: 38px;
+          height: 38px;
+          border-radius: 12px;
+        }
+
         .screen {
           padding: 14px 12px;
         }
@@ -859,20 +877,20 @@
       <section class="screen-section" aria-labelledby="panel-estado">
         <div class="screen" role="region" aria-live="polite">
           <div class="status-strip">
+            <div class="identity">
+              <div class="identity-avatar" aria-hidden="true">🐈‍⬛</div>
+              <div class="identity-meta">
+                <label class="name-field" for="catName">
+                  <span>Nombre</span>
+                  <input id="catName" maxlength="16" placeholder="PIXEL" />
+                </label>
+                <span class="level-pill" aria-live="polite">Nv. <strong id="level-label">1</strong></span>
+              </div>
+            </div>
             <button class="day-switch" id="daySwitch" type="button" aria-label="Cambiar entorno">
               <span id="dayEmoji">🌞</span>
               <span id="dayLabel">Parque soleado</span>
             </button>
-            <div class="status-meta">
-              <label class="name-field" for="catName">
-                <span>Nombre</span>
-                <input id="catName" maxlength="16" placeholder="PIXEL" />
-              </label>
-              <div class="info-chips">
-                <div class="chip">Nivel <strong id="level-label">1</strong></div>
-                <div class="chip">Vet <strong id="vet-timer">--:--</strong></div>
-              </div>
-            </div>
           </div>
           <div class="scene" id="catScene">
             <div class="scene-floor"></div>
@@ -882,30 +900,30 @@
                 <svg viewBox="0 0 240 240" role="img" aria-label="Gato virtual">
                   <defs>
                     <radialGradient id="furMain" cx="50%" cy="30%" r="75%">
-                      <stop offset="0%" stop-color="#fff4fb" />
-                      <stop offset="60%" stop-color="#f9c2e3" />
-                      <stop offset="100%" stop-color="#ec8fc6" />
+                      <stop offset="0%" stop-color="#4f5662" />
+                      <stop offset="55%" stop-color="#242832" />
+                      <stop offset="100%" stop-color="#0e1118" />
                     </radialGradient>
                     <radialGradient id="furBelly" cx="50%" cy="40%" r="75%">
-                      <stop offset="0%" stop-color="#fffdfc" />
-                      <stop offset="100%" stop-color="#ffe1f0" />
+                      <stop offset="0%" stop-color="#ffffff" />
+                      <stop offset="100%" stop-color="#e8edf5" />
+                    </radialGradient>
+                    <radialGradient id="faceMask" cx="50%" cy="50%" r="70%">
+                      <stop offset="0%" stop-color="#ffffff" />
+                      <stop offset="100%" stop-color="#eef2f7" />
                     </radialGradient>
                     <linearGradient id="tailGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-                      <stop offset="0%" stop-color="#f6b3de" />
-                      <stop offset="100%" stop-color="#d76aa9" />
+                      <stop offset="0%" stop-color="#505867" />
+                      <stop offset="100%" stop-color="#181c25" />
                     </linearGradient>
                     <radialGradient id="earInner" cx="50%" cy="50%" r="70%">
-                      <stop offset="0%" stop-color="#ffd6ef" />
-                      <stop offset="100%" stop-color="#f79fd1" />
+                      <stop offset="0%" stop-color="#ffd6e6" />
+                      <stop offset="100%" stop-color="#f1a7c5" />
                     </radialGradient>
                     <radialGradient id="cheekGradient" cx="50%" cy="50%" r="50%">
-                      <stop offset="0%" stop-color="#ffb1cb" />
-                      <stop offset="100%" stop-color="#ff80b4" />
+                      <stop offset="0%" stop-color="#ffd1dc" />
+                      <stop offset="100%" stop-color="#f9a6bf" />
                     </radialGradient>
-                    <linearGradient id="stripeGradient" x1="0%" y1="0%" x2="0%" y2="100%">
-                      <stop offset="0%" stop-color="rgba(209, 84, 152, 0.25)" />
-                      <stop offset="100%" stop-color="rgba(209, 84, 152, 0)" />
-                    </linearGradient>
                   </defs>
                   <g id="tail">
                     <path
@@ -928,43 +946,29 @@
                     <path
                       d="M66 134 C44 158 50 198 86 214 C120 230 170 220 190 186 C204 162 198 124 172 106 C150 90 124 92 102 100 C86 106 74 118 66 134 Z"
                       fill="url(#furMain)"
-                      stroke="#cf6ba9"
+                      stroke="#1f2230"
                       stroke-width="4"
                       stroke-linejoin="round"
                     />
                     <path
                       d="M94 152 C82 172 92 200 120 208 C150 216 174 198 176 170 C178 144 156 128 132 128 C116 128 102 136 94 152 Z"
                       fill="url(#furBelly)"
-                      stroke="rgba(255, 255, 255, 0.4)"
+                      stroke="rgba(255, 255, 255, 0.6)"
                       stroke-width="2"
-                    />
-                    <path
-                      d="M88 150 C100 134 118 126 132 126"
-                      fill="none"
-                      stroke="url(#stripeGradient)"
-                      stroke-width="12"
-                      stroke-linecap="round"
-                    />
-                    <path
-                      d="M150 150 C164 140 170 122 168 110"
-                      fill="none"
-                      stroke="url(#stripeGradient)"
-                      stroke-width="10"
-                      stroke-linecap="round"
                     />
                   </g>
                   <g id="head">
                     <path
                       d="M86 72 L66 40 L102 56 Z"
                       fill="url(#furMain)"
-                      stroke="#cf6ba9"
+                      stroke="#1f2230"
                       stroke-width="4"
                       stroke-linejoin="round"
                     />
                     <path
                       d="M178 72 L198 40 L162 56 Z"
                       fill="url(#furMain)"
-                      stroke="#cf6ba9"
+                      stroke="#1f2230"
                       stroke-width="4"
                       stroke-linejoin="round"
                     />
@@ -973,74 +977,67 @@
                     <path
                       d="M74 124 C70 92 92 60 126 56 C162 52 194 78 194 116 C194 146 172 170 140 170 C108 170 84 150 74 124 Z"
                       fill="url(#furMain)"
-                      stroke="#cf6ba9"
+                      stroke="#1f2230"
                       stroke-width="4"
                       stroke-linejoin="round"
                     />
-                    <path
-                      d="M120 74 C110 80 102 92 100 104"
-                      fill="none"
-                      stroke="rgba(207, 107, 169, 0.5)"
-                      stroke-width="6"
-                      stroke-linecap="round"
-                    />
-                    <path
-                      d="M162 74 C172 80 180 92 182 106"
-                      fill="none"
-                      stroke="rgba(207, 107, 169, 0.5)"
-                      stroke-width="6"
-                      stroke-linecap="round"
-                    />
                   </g>
                   <g id="face">
-                    <ellipse cx="116" cy="118" rx="16" ry="20" fill="#fff" opacity="0.85" />
-                    <ellipse cx="160" cy="118" rx="16" ry="20" fill="#fff" opacity="0.85" />
-                    <circle cx="116" cy="120" r="8" fill="#251431" />
-                    <circle cx="160" cy="120" r="8" fill="#251431" />
-                    <circle cx="112" cy="116" r="3" fill="#fff" opacity="0.7" />
-                    <circle cx="156" cy="116" r="3" fill="#fff" opacity="0.7" />
-                    <polygon points="130,122 122,130 130,136 138,130" fill="#f7a7c4" stroke="#cf6ba9" stroke-width="2" />
                     <path
-                      d="M130 136 Q130 144 122 148"
+                      d="M96 98 C86 120 90 150 112 170 C130 186 154 188 172 172 C194 154 200 124 190 100 C180 76 154 66 128 72 C112 76 102 86 96 98 Z"
+                      fill="url(#faceMask)"
+                      stroke="rgba(255, 255, 255, 0.75)"
+                      stroke-width="3"
+                      stroke-linejoin="round"
+                    />
+                    <ellipse cx="120" cy="150" rx="20" ry="24" fill="#ffffff" opacity="0.95" />
+                    <ellipse cx="168" cy="150" rx="20" ry="24" fill="#ffffff" opacity="0.95" />
+                    <circle class="pupil" cx="120" cy="154" r="9" fill="#0e1018" />
+                    <circle class="pupil" cx="168" cy="154" r="9" fill="#0e1018" />
+                    <circle cx="116" cy="148" r="3" fill="#ffffff" opacity="0.75" />
+                    <circle cx="164" cy="148" r="3" fill="#ffffff" opacity="0.75" />
+                    <path
+                      d="M132 148 L140 158 L148 148 Z"
+                      fill="#f3b7c9"
+                      stroke="#c67c8f"
+                      stroke-width="2"
+                      stroke-linejoin="round"
+                    />
+                    <path
+                      id="mouth"
+                      d="M130 172 Q144 184 158 172"
                       fill="none"
-                      stroke="#cf6ba9"
+                      stroke="#c67c8f"
                       stroke-width="4"
                       stroke-linecap="round"
                     />
+                    <circle cx="108" cy="166" r="9" fill="url(#cheekGradient)" opacity="0.65" />
+                    <circle cx="180" cy="166" r="9" fill="url(#cheekGradient)" opacity="0.65" />
                     <path
-                      d="M130 136 Q130 144 138 148"
+                      d="M92 150 Q110 146 128 150"
                       fill="none"
-                      stroke="#cf6ba9"
-                      stroke-width="4"
-                      stroke-linecap="round"
-                    />
-                    <circle cx="106" cy="134" r="8" fill="url(#cheekGradient)" opacity="0.7" />
-                    <circle cx="170" cy="134" r="8" fill="url(#cheekGradient)" opacity="0.7" />
-                    <path
-                      d="M96 124 Q110 128 122 126"
-                      fill="none"
-                      stroke="#532247"
+                      stroke="#1f2230"
                       stroke-width="3"
                       stroke-linecap="round"
                     />
                     <path
-                      d="M138 126 Q150 128 164 124"
+                      d="M160 150 Q178 146 196 150"
                       fill="none"
-                      stroke="#532247"
+                      stroke="#1f2230"
                       stroke-width="3"
                       stroke-linecap="round"
                     />
                     <path
-                      d="M94 136 Q112 140 130 138"
+                      d="M94 162 Q114 158 134 164"
                       fill="none"
-                      stroke="rgba(83, 34, 71, 0.5)"
+                      stroke="rgba(31, 34, 48, 0.55)"
                       stroke-width="3"
                       stroke-linecap="round"
                     />
                     <path
-                      d="M130 138 Q148 140 166 136"
+                      d="M154 164 Q174 158 194 162"
                       fill="none"
-                      stroke="rgba(83, 34, 71, 0.5)"
+                      stroke="rgba(31, 34, 48, 0.55)"
                       stroke-width="3"
                       stroke-linecap="round"
                     />
@@ -1061,10 +1058,7 @@
           <div class="button-row">
             <button class="device-button" data-action="feed" data-label="Comer" aria-label="Alimentar">🍣</button>
             <button class="device-button" data-action="play" data-label="Jugar" aria-label="Jugar">🧶</button>
-            <button class="device-button" data-action="groom" data-label="Aseo" aria-label="Baño y cepillado">🛁</button>
-            <button class="device-button" data-action="nap" data-label="Dormir" aria-label="Siestita">😴</button>
-            <button class="device-button" data-action="vet" data-label="Vet" aria-label="Visita al veterinario">💉</button>
-            <button class="device-button" data-action="surprise" data-label="Sorp" aria-label="Sorpresa">🎁</button>
+            <button class="device-button" data-action="nap" data-label="Siesta" aria-label="Tomar una siesta">😴</button>
           </div>
           <div class="screen-hud">
             <div class="hud-top">
@@ -1091,24 +1085,10 @@
               </article>
               <article class="stat" data-theme="fun">
                 <div class="stat-title">
-                  <span>Diversión</span>
+                  <span>Ánimo</span>
                   <span class="stat-value" id="funValue">80%</span>
                 </div>
                 <div class="progress-bar"><div class="progress-fill" id="funBar"></div></div>
-              </article>
-              <article class="stat">
-                <div class="stat-title">
-                  <span>Aseo</span>
-                  <span class="stat-value" id="cleanValue">80%</span>
-                </div>
-                <div class="progress-bar"><div class="progress-fill" id="cleanBar"></div></div>
-              </article>
-              <article class="stat" data-theme="health">
-                <div class="stat-title">
-                  <span>Salud</span>
-                  <span class="stat-value" id="healthValue">80%</span>
-                </div>
-                <div class="progress-bar"><div class="progress-fill" id="healthBar"></div></div>
               </article>
             </div>
           </div>
@@ -1138,7 +1118,6 @@
       const MAX_STAT = 100;
       const catNameInput = document.getElementById("catName");
       const levelLabel = document.getElementById("level-label");
-      const vetTimer = document.getElementById("vet-timer");
       const daySwitch = document.getElementById("daySwitch");
       const dayEmoji = document.getElementById("dayEmoji");
       const dayLabel = document.getElementById("dayLabel");
@@ -1151,10 +1130,6 @@
       const energyValue = document.getElementById("energyValue");
       const funBar = document.getElementById("funBar");
       const funValue = document.getElementById("funValue");
-      const cleanBar = document.getElementById("cleanBar");
-      const cleanValue = document.getElementById("cleanValue");
-      const healthBar = document.getElementById("healthBar");
-      const healthValue = document.getElementById("healthValue");
       const xpBar = document.getElementById("xpBar");
       const moodLabel = document.getElementById("moodLabel");
       const toast = document.getElementById("toast");
@@ -1168,13 +1143,10 @@
         hunger: 80,
         energy: 80,
         fun: 80,
-        clean: 80,
-        health: 80,
         xp: 0,
         level: 1,
         lastTick: Date.now(),
         history: [],
-        vetCooldown: 0,
         accessoriesUnlocked: false,
         dayMode: "day",
       };
@@ -1185,56 +1157,27 @@
         feed: {
           emoji: "🍣",
           text: () => `${getName()} disfruta del mejor salmón nigiri.`,
-          effects: { hunger: +24, fun: +6, energy: -4, clean: -6 },
+          effects: { hunger: +26, fun: +6, energy: -4 },
           xp: 12,
         },
         play: {
           emoji: "🧶",
           text: () => `${getName()} persigue el ovillo como si fuera la última vez.`,
-          effects: { fun: +24, energy: -12, hunger: -8, health: +3 },
+          effects: { fun: +24, energy: -12, hunger: -8 },
           xp: 16,
-        },
-        groom: {
-          emoji: "🛁",
-          text: () => `Sesión de spa: ${getName()} queda impecable y relajado.`,
-          effects: { clean: +26, health: +10, fun: -4 },
-          xp: 14,
         },
         nap: {
           emoji: "😴",
           text: () => `${getName()} ronronea mientras duerme la siesta.`,
-          effects: { energy: +32, hunger: -8, fun: -6, health: +4 },
+          effects: { energy: +32, hunger: -8, fun: -4 },
           xp: 10,
-        },
-        vet: {
-          emoji: "💉",
-          text: () => `Visita médica: ${getName()} recibe una revisión completa.`,
-          effects: { health: +28, fun: -12, energy: -6, clean: -4 },
-          xp: 18,
-          cooldown: 120000,
-        },
-        surprise: {
-          emoji: "🎁",
-          text: () => {
-            const surprises = [
-              `¡Nueva pluma brillante! ${getName()} salta de emoción.`,
-              `${getName()} descubre un rayo de sol perfecto para dormir.`,
-              `Encuentras una caja misteriosa. Dentro había snacks crujientes.`,
-              `${getName()} aprende un truco nuevo y lo presume orgulloso.`,
-            ];
-            return surprises[Math.floor(Math.random() * surprises.length)];
-          },
-          effects: () => randomSurpriseEffects(),
-          xp: 20,
         },
       };
 
       const baseDegradeRates = {
-        hunger: -2.6,
-        energy: -2.2,
-        fun: -2.4,
-        clean: -1.8,
-        health: -0.5,
+        hunger: -2.5,
+        energy: -2,
+        fun: -2.3,
       };
 
       let degradeRates = { ...baseDegradeRates };
@@ -1267,7 +1210,6 @@
 
         updateUI();
         updateDayMode();
-        updateVetTimer();
         startCatWander();
       }
 
@@ -1276,7 +1218,9 @@
           const stored = localStorage.getItem(STORAGE_KEY);
           if (!stored) return structuredClone(defaultState);
           const parsed = JSON.parse(stored);
-          return { ...structuredClone(defaultState), ...parsed };
+          const merged = { ...structuredClone(defaultState), ...parsed };
+          const { clean, health, vetCooldown, ...safeState } = merged;
+          return safeState;
         } catch (error) {
           console.error("Error cargando estado", error);
           return structuredClone(defaultState);
@@ -1301,39 +1245,27 @@
           modifyStat(stat, rate * delta);
         });
 
-        if (state.hunger < 35 || state.clean < 30 || state.fun < 30) {
-          modifyStat("health", -1.5 * delta);
+        if (state.hunger < 30) {
+          modifyStat("fun", -1.4 * delta);
         }
         if (state.energy < 25) {
-          modifyStat("fun", -1.2 * delta);
+          modifyStat("fun", -1 * delta);
         }
-
-        if (state.vetCooldown > 0) {
-          state.vetCooldown = Math.max(0, state.vetCooldown - tickInterval);
+        if (state.fun < 25) {
+          modifyStat("energy", -0.8 * delta);
         }
 
         updateUI();
         saveState();
-        updateVetTimer();
       }
 
       function modifyStat(stat, amount) {
-        const prev = state[stat];
         state[stat] = clamp(state[stat] + amount, MIN_STAT, MAX_STAT);
-        if (stat === "health" && prev > 20 && state.health <= 20) {
-          showToast("⚠️", `${getName()} necesita atención urgente.`);
-        }
       }
 
       function handleAction(actionKey) {
         const action = actions[actionKey];
         if (!action) return;
-
-        if (actionKey === "vet" && state.vetCooldown > 0) {
-          const seconds = Math.ceil(state.vetCooldown / 1000);
-          showToast("⏳", `Aún faltan ${seconds}s para la próxima visita.`);
-          return;
-        }
 
         let effects = action.effects;
         if (typeof effects === "function") {
@@ -1343,11 +1275,6 @@
         Object.entries(effects).forEach(([stat, value]) => modifyStat(stat, value));
         gainXp(action.xp);
         addLogEntry({ emoji: action.emoji, message: action.text(), timestamp: Date.now() });
-
-        if (action.cooldown) {
-          state.vetCooldown = action.cooldown;
-          updateVetTimer();
-        }
 
         if (!state.accessoriesUnlocked && state.level >= 3) {
           state.accessoriesUnlocked = true;
@@ -1375,7 +1302,7 @@
       }
 
       function getMood() {
-        const avg = (state.hunger + state.energy + state.fun + state.clean + state.health) / 5;
+        const avg = (state.hunger + state.energy + state.fun) / 3;
         if (avg > 80) return { key: "feliz", label: "✨ Feliz" };
         if (avg > 60) return { key: "contento", label: "😺 Contento" };
         if (avg > 40) return { key: "neutro", label: "😐 Pensativo" };
@@ -1387,8 +1314,6 @@
         updateStat(hungerBar, hungerValue, state.hunger);
         updateStat(energyBar, energyValue, state.energy);
         updateStat(funBar, funValue, state.fun);
-        updateStat(cleanBar, cleanValue, state.clean);
-        updateStat(healthBar, healthValue, state.health);
         updateXP();
 
         const mood = getMood();
@@ -1424,36 +1349,36 @@
         const pupils = document.querySelectorAll(".pupil");
         switch (moodKey) {
           case "feliz":
-            mouth.setAttribute("d", "M140 190 Q160 215 180 190");
-            pupils.forEach((p) => p.setAttribute("cy", "158"));
+            mouth.setAttribute("d", "M126 168 Q144 186 162 168");
+            pupils.forEach((p) => p.setAttribute("cy", "152"));
             catWanderer.style.setProperty("--scale", "1.05");
             catWanderer.style.setProperty("--bob-speed", "2.4s");
             catWanderer.style.setProperty("--shadow-opacity", "0.5");
             break;
           case "contento":
-            mouth.setAttribute("d", "M145 190 Q160 200 175 190");
-            pupils.forEach((p) => p.setAttribute("cy", "160"));
+            mouth.setAttribute("d", "M130 172 Q144 182 158 172");
+            pupils.forEach((p) => p.setAttribute("cy", "154"));
             catWanderer.style.setProperty("--scale", "1");
             catWanderer.style.setProperty("--bob-speed", "2.8s");
             catWanderer.style.setProperty("--shadow-opacity", "0.45");
             break;
           case "neutro":
-            mouth.setAttribute("d", "M145 188 Q160 188 175 188");
-            pupils.forEach((p) => p.setAttribute("cy", "162"));
+            mouth.setAttribute("d", "M132 172 Q144 172 156 172");
+            pupils.forEach((p) => p.setAttribute("cy", "156"));
             catWanderer.style.setProperty("--scale", "0.98");
             catWanderer.style.setProperty("--bob-speed", "3.2s");
             catWanderer.style.setProperty("--shadow-opacity", "0.4");
             break;
           case "triste":
-            mouth.setAttribute("d", "M145 192 Q160 178 175 192");
-            pupils.forEach((p) => p.setAttribute("cy", "166"));
+            mouth.setAttribute("d", "M132 176 Q144 166 156 176");
+            pupils.forEach((p) => p.setAttribute("cy", "160"));
             catWanderer.style.setProperty("--scale", "0.96");
             catWanderer.style.setProperty("--bob-speed", "3.6s");
             catWanderer.style.setProperty("--shadow-opacity", "0.35");
             break;
           default:
-            mouth.setAttribute("d", "M138 192 Q160 170 182 192");
-            pupils.forEach((p) => p.setAttribute("cy", "170"));
+            mouth.setAttribute("d", "M130 178 Q144 160 158 178");
+            pupils.forEach((p) => p.setAttribute("cy", "164"));
             catWanderer.style.setProperty("--scale", "0.94");
             catWanderer.style.setProperty("--bob-speed", "3.8s");
             catWanderer.style.setProperty("--shadow-opacity", "0.32");
@@ -1489,29 +1414,8 @@
         }, 3200);
       }
 
-      function randomSurpriseEffects() {
-        const outcomes = [
-          { hunger: +12, fun: +18, clean: -6, energy: -4 },
-          { fun: +24, health: +6 },
-          { energy: +14, fun: +10 },
-          { health: +12, clean: +8 },
-          { hunger: +16, fun: -4 },
-        ];
-        return outcomes[Math.floor(Math.random() * outcomes.length)];
-      }
-
       function clamp(value, min, max) {
         return Math.min(Math.max(value, min), max);
-      }
-
-      function updateVetTimer() {
-        if (state.vetCooldown <= 0) {
-          vetTimer.textContent = "listo";
-          return;
-        }
-        const minutes = Math.floor(state.vetCooldown / 60000);
-        const seconds = Math.floor((state.vetCooldown % 60000) / 1000);
-        vetTimer.textContent = `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
       }
 
       function toggleAccessory(show) {


### PR DESCRIPTION
## Summary
- rediseñé el encabezado del dispositivo para mostrar el nombre y el nivel en un bloque compacto junto al selector de entorno
- actualicé el gato virtual con una ilustración estilo tuxedo y nuevas animaciones faciales asociadas al estado de ánimo
- reduje las acciones y barras de estado a tres valores y ajusté la lógica de degradación y XP para la versión simplificada

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cfe1259c90832bb1ac651d8fa93cd6