### PR TITLE
Adjust cat face layout and add real cat audio

### DIFF
--- a/index.html
+++ b/index.html
@@ -1150,23 +1150,23 @@
                     />
                     <g id="faceFeatures">
                       <g id="eyesOpen">
-                        <ellipse id="eyeLeft" cx="120" cy="150" rx="20" ry="24" fill="#ffffff" opacity="0.95" />
-                        <ellipse id="eyeRight" cx="168" cy="150" rx="20" ry="24" fill="#ffffff" opacity="0.95" />
-                        <circle class="pupil" id="pupilLeft" cx="120" cy="154" r="9" fill="#0e1018" />
-                        <circle class="pupil" id="pupilRight" cx="168" cy="154" r="9" fill="#0e1018" />
-                        <circle cx="116" cy="148" r="3" fill="#ffffff" opacity="0.75" />
-                        <circle cx="164" cy="148" r="3" fill="#ffffff" opacity="0.75" />
+                        <ellipse id="eyeLeft" cx="120" cy="142" rx="20" ry="24" fill="#ffffff" opacity="0.95" />
+                        <ellipse id="eyeRight" cx="168" cy="142" rx="20" ry="24" fill="#ffffff" opacity="0.95" />
+                        <circle class="pupil" id="pupilLeft" cx="120" cy="146" r="9" fill="#0e1018" />
+                        <circle class="pupil" id="pupilRight" cx="168" cy="146" r="9" fill="#0e1018" />
+                        <circle cx="116" cy="140" r="3" fill="#ffffff" opacity="0.75" />
+                        <circle cx="164" cy="140" r="3" fill="#ffffff" opacity="0.75" />
                       </g>
                       <g id="eyesClosed" opacity="0">
                         <path
-                          d="M102 150 Q120 144 138 150"
+                          d="M102 142 Q120 136 138 142"
                           fill="none"
                           stroke="#1f2230"
                           stroke-width="4"
                           stroke-linecap="round"
                         />
                         <path
-                          d="M150 150 Q168 144 186 150"
+                          d="M150 142 Q168 136 186 142"
                           fill="none"
                           stroke="#1f2230"
                           stroke-width="4"
@@ -1175,7 +1175,7 @@
                       </g>
                       <path
                         id="nose"
-                        d="M132 148 L140 158 L148 148 Z"
+                        d="M132 140 L140 150 L148 140 Z"
                         fill="#f3b7c9"
                         stroke="#c67c8f"
                         stroke-width="2"
@@ -1183,38 +1183,38 @@
                       />
                       <path
                         id="mouth"
-                        d="M130 172 Q144 184 158 172"
+                        d="M130 164 Q144 176 158 164"
                         fill="none"
                         stroke="#c67c8f"
                         stroke-width="4"
                         stroke-linecap="round"
                       />
-                      <circle cx="108" cy="166" r="9" fill="url(#cheekGradient)" opacity="0.65" />
-                      <circle cx="180" cy="166" r="9" fill="url(#cheekGradient)" opacity="0.65" />
+                      <circle cx="108" cy="158" r="9" fill="url(#cheekGradient)" opacity="0.65" />
+                      <circle cx="180" cy="158" r="9" fill="url(#cheekGradient)" opacity="0.65" />
                       <g id="whiskers">
                         <path
-                          d="M88 150 Q110 142 132 150"
+                          d="M88 142 Q110 134 132 142"
                           fill="none"
                           stroke="#1f2230"
                           stroke-width="3"
                           stroke-linecap="round"
                         />
                         <path
-                          d="M88 162 Q110 156 132 164"
+                          d="M88 154 Q110 148 132 156"
                           fill="none"
                           stroke="rgba(31, 34, 48, 0.55)"
                           stroke-width="3"
                           stroke-linecap="round"
                         />
                         <path
-                          d="M168 150 Q190 142 212 150"
+                          d="M168 142 Q190 134 212 142"
                           fill="none"
                           stroke="#1f2230"
                           stroke-width="3"
                           stroke-linecap="round"
                         />
                         <path
-                          d="M168 162 Q190 156 212 164"
+                          d="M168 154 Q190 148 212 156"
                           fill="none"
                           stroke="rgba(31, 34, 48, 0.55)"
                           stroke-width="3"
@@ -1482,6 +1482,7 @@
         },
       };
 
+      const samplePlayer = createSamplePlayer();
       const soundEngine = createSoundEngine();
 
       function createMeowPattern({ base = 460, stretch = 1, volume = 0.5 } = {}) {
@@ -1541,6 +1542,20 @@
       };
 
       function playSoundEffect(effectKey) {
+        if (samplePlayer) {
+          const playback = samplePlayer.play(effectKey);
+          if (playback && typeof playback.catch === "function") {
+            playback.catch(() => playSynthEffect(effectKey));
+            return;
+          }
+          if (playback) {
+            return;
+          }
+        }
+        playSynthEffect(effectKey);
+      }
+
+      function playSynthEffect(effectKey) {
         if (!soundEngine) return;
         const generator = soundPatterns[effectKey];
         if (!generator) return;
@@ -1925,8 +1940,8 @@
         };
 
         if (activity === "nap") {
-          setPupils("158", 6);
-          mouth.setAttribute("d", "M132 176 Q144 178 156 176");
+          setPupils("150", 6);
+          mouth.setAttribute("d", "M132 168 Q144 170 156 168");
           catWanderer.style.setProperty("--scale", "0.94");
           catWanderer.style.setProperty("--bob-speed", "4.4s");
           catWanderer.style.setProperty("--shadow-opacity", "0.32");
@@ -1934,8 +1949,8 @@
         }
 
         if (activity === "feed") {
-          setPupils("150", 10);
-          mouth.setAttribute("d", "M126 170 Q144 200 162 170");
+          setPupils("142", 10);
+          mouth.setAttribute("d", "M126 162 Q144 192 162 162");
           catWanderer.style.setProperty("--scale", "1.07");
           catWanderer.style.setProperty("--bob-speed", "2.2s");
           catWanderer.style.setProperty("--shadow-opacity", "0.52");
@@ -1943,8 +1958,8 @@
         }
 
         if (activity === "play") {
-          setPupils("150", 11);
-          mouth.setAttribute("d", "M124 168 Q144 196 164 168");
+          setPupils("142", 11);
+          mouth.setAttribute("d", "M124 160 Q144 188 164 160");
           catWanderer.style.setProperty("--scale", "1.08");
           catWanderer.style.setProperty("--bob-speed", "2s");
           catWanderer.style.setProperty("--shadow-opacity", "0.55");
@@ -1953,36 +1968,36 @@
 
         switch (moodKey) {
           case "feliz":
-            mouth.setAttribute("d", "M126 168 Q144 186 162 168");
-            setPupils("152", 9);
+            mouth.setAttribute("d", "M126 160 Q144 178 162 160");
+            setPupils("144", 9);
             catWanderer.style.setProperty("--scale", "1.05");
             catWanderer.style.setProperty("--bob-speed", "2.4s");
             catWanderer.style.setProperty("--shadow-opacity", "0.5");
             break;
           case "contento":
-            mouth.setAttribute("d", "M130 172 Q144 182 158 172");
-            setPupils("154", 9);
+            mouth.setAttribute("d", "M130 164 Q144 174 158 164");
+            setPupils("146", 9);
             catWanderer.style.setProperty("--scale", "1");
             catWanderer.style.setProperty("--bob-speed", "2.8s");
             catWanderer.style.setProperty("--shadow-opacity", "0.45");
             break;
           case "neutro":
-            mouth.setAttribute("d", "M132 172 Q144 172 156 172");
-            setPupils("156", 8);
+            mouth.setAttribute("d", "M132 164 Q144 164 156 164");
+            setPupils("148", 8);
             catWanderer.style.setProperty("--scale", "0.98");
             catWanderer.style.setProperty("--bob-speed", "3.2s");
             catWanderer.style.setProperty("--shadow-opacity", "0.4");
             break;
           case "triste":
-            mouth.setAttribute("d", "M132 176 Q144 166 156 176");
-            setPupils("160", 7);
+            mouth.setAttribute("d", "M132 168 Q144 158 156 168");
+            setPupils("152", 7);
             catWanderer.style.setProperty("--scale", "0.96");
             catWanderer.style.setProperty("--bob-speed", "3.6s");
             catWanderer.style.setProperty("--shadow-opacity", "0.35");
             break;
           default:
-            mouth.setAttribute("d", "M130 178 Q144 160 158 178");
-            setPupils("164", 7);
+            mouth.setAttribute("d", "M130 170 Q144 152 158 170");
+            setPupils("156", 7);
             catWanderer.style.setProperty("--scale", "0.94");
             catWanderer.style.setProperty("--bob-speed", "3.8s");
             catWanderer.style.setProperty("--shadow-opacity", "0.32");
@@ -2020,6 +2035,96 @@
 
       function clamp(value, min, max) {
         return Math.min(Math.max(value, min), max);
+      }
+
+      function createSamplePlayer() {
+        if (typeof Audio === "undefined") {
+          return null;
+        }
+
+        const definitions = {
+          meow: {
+            sources: ["meow-1.mp3", "meow_QO6VsE6.mp3", "the-end-meow-by-nekocat-just-3-second-1.mp3"],
+            volume: 0.58,
+          },
+          purr: {
+            sources: ["cat-purr.mp3", "little-puff-purr.mp3", "little-puff-purr-brr.mp3"],
+            volume: 0.4,
+          },
+        };
+
+        const aliases = {
+          feed: "meow",
+          play: "meow",
+          nap: "purr",
+        };
+
+        function createAudioPool(sources, { volume = 0.5 } = {}) {
+          const entries = sources
+            .filter(Boolean)
+            .map((src) => {
+              const element = new Audio(src);
+              element.preload = "auto";
+              element.volume = volume;
+              element.load();
+              return { src, instances: [element], volume };
+            });
+
+          function getInstance(entry) {
+            if (!entry) return null;
+            const available = entry.instances.find((audio) => audio.paused);
+            if (available) {
+              return available;
+            }
+            const clone = entry.instances[0]?.cloneNode(true) || new Audio(entry.src);
+            clone.volume = entry.volume;
+            clone.preload = "auto";
+            entry.instances.push(clone);
+            return clone;
+          }
+
+          function play() {
+            if (entries.length === 0) {
+              return null;
+            }
+            const entry = entries[Math.floor(Math.random() * entries.length)];
+            const audio = getInstance(entry);
+            if (!audio) {
+              return null;
+            }
+            audio.currentTime = 0;
+            try {
+              const maybePromise = audio.play();
+              if (maybePromise && typeof maybePromise.then === "function") {
+                return maybePromise;
+              }
+              return Promise.resolve();
+            } catch (error) {
+              return Promise.reject(error);
+            }
+          }
+
+          return { play };
+        }
+
+        const pools = Object.entries(definitions).reduce((acc, [key, config]) => {
+          const pool = createAudioPool(config.sources, config);
+          if (pool) {
+            acc[key] = pool;
+          }
+          return acc;
+        }, {});
+
+        return {
+          play(effectKey) {
+            const targetKey = pools[effectKey] ? effectKey : aliases[effectKey];
+            const pool = targetKey ? pools[targetKey] : null;
+            if (!pool || typeof pool.play !== "function") {
+              return null;
+            }
+            return pool.play();
+          },
+        };
       }
 
       function createSoundEngine() {


### PR DESCRIPTION
## Summary
- reposition the cat's facial features higher on its face for a cuter look
- wire up real meow and purr audio samples with pooling and fallback to the synth engine

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d0000568cc832ba072246a594f7bbb