### PR TITLE
feat: replace cat with pixel art skins

### DIFF
--- a/index.html
+++ b/index.html
@@ -308,17 +308,31 @@
         transform-origin: center bottom;
         animation: bob var(--bob-speed) ease-in-out infinite;
         filter: drop-shadow(0 10px 18px rgba(112, 41, 104, 0.25));
+        --fur-main: #2f2c3d;
+        --fur-secondary: #262338;
+        --fur-accent: #454058;
+        --belly: #d8dbe8;
+        --ear-inner: #f3adc9;
+        --cheek: #f48fbf;
+        --outline: #08050f;
+        --paw: #e8ecf7;
+        --collar: #6ee7ff;
+        --collar-stroke: #4aa5ff;
+        --pupil: #0e1018;
+        --nose: #f3adc9;
       }
 
       .cat svg {
         width: 100%;
         height: auto;
+        image-rendering: pixelated;
+        shape-rendering: crispEdges;
       }
 
       #faceFeatures {
         transform-box: fill-box;
         transform-origin: center;
-        transform: translateY(-26px);
+        transform: translateY(-6px);
         transition: transform 0.35s ease;
       }
 
@@ -332,15 +346,15 @@
       }
 
       .cat[data-activity="feed"] #faceFeatures {
-        transform: translateY(-28px);
+        transform: translateY(-8px);
       }
 
       .cat[data-activity="play"] #faceFeatures {
-        transform: translateY(-24px);
+        transform: translateY(-4px);
       }
 
       .cat[data-activity="nap"] #faceFeatures {
-        transform: translateY(-20px);
+        transform: translateY(-2px);
       }
 
       .cat[data-activity="nap"] #eyesOpen {
@@ -358,11 +372,11 @@
       }
 
       .cat[data-activity="feed"] #whiskers {
-        transform: translateY(-2px);
+        transform: translateY(-1px);
       }
 
       .cat[data-activity="nap"] #whiskers {
-        transform: translateY(3px);
+        transform: translateY(1px);
       }
 
       .cat[data-activity="play"] #whiskers {
@@ -1052,229 +1066,121 @@
             <div class="cat-wanderer" id="catWanderer">
               <div class="cat-shadow"></div>
               <div class="cat" id="cat" data-mood="feliz" data-activity="idle">
-                <svg viewBox="0 0 240 240" role="img" aria-label="Gato virtual">
-                  <defs>
-                    <radialGradient id="furMain" cx="50%" cy="30%" r="75%">
-                      <stop offset="0%" stop-color="#4f5662" />
-                      <stop offset="55%" stop-color="#242832" />
-                      <stop offset="100%" stop-color="#0e1118" />
-                    </radialGradient>
-                    <radialGradient id="furBelly" cx="50%" cy="40%" r="75%">
-                      <stop offset="0%" stop-color="#ffffff" />
-                      <stop offset="100%" stop-color="#e8edf5" />
-                    </radialGradient>
-                    <radialGradient id="faceMask" cx="50%" cy="50%" r="70%">
-                      <stop offset="0%" stop-color="#ffffff" />
-                      <stop offset="100%" stop-color="#eef2f7" />
-                    </radialGradient>
-                    <linearGradient id="tailGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-                      <stop offset="0%" stop-color="#505867" />
-                      <stop offset="100%" stop-color="#181c25" />
-                    </linearGradient>
-                    <radialGradient id="earInner" cx="50%" cy="50%" r="70%">
-                      <stop offset="0%" stop-color="#ffd6e6" />
-                      <stop offset="100%" stop-color="#f1a7c5" />
-                    </radialGradient>
-                    <radialGradient id="cheekGradient" cx="50%" cy="50%" r="50%">
-                      <stop offset="0%" stop-color="#ffd1dc" />
-                      <stop offset="100%" stop-color="#f9a6bf" />
-                    </radialGradient>
-                  </defs>
-                  <g id="tail">
-                    <path
-                      d="M170 158 C202 150 212 122 198 98 C186 76 156 76 136 94"
-                      fill="none"
-                      stroke="url(#tailGradient)"
-                      stroke-width="18"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                    />
-                    <path
-                      d="M170 158 C190 160 204 148 208 132"
-                      fill="none"
-                      stroke="rgba(255, 255, 255, 0.45)"
-                      stroke-width="6"
-                      stroke-linecap="round"
-                    />
-                  </g>
-                  <g id="cat-body">
-                    <path
-                      d="M66 134 C44 158 50 198 86 214 C120 230 170 220 190 186 C204 162 198 124 172 106 C150 90 124 92 102 100 C86 106 74 118 66 134 Z"
-                      fill="url(#furMain)"
-                      stroke="#1f2230"
-                      stroke-width="4"
-                      stroke-linejoin="round"
-                    />
-                    <path
-                      d="M94 152 C82 172 92 200 120 208 C150 216 174 198 176 170 C178 144 156 128 132 128 C116 128 102 136 94 152 Z"
-                      fill="url(#furBelly)"
-                      stroke="rgba(255, 255, 255, 0.6)"
-                      stroke-width="2"
-                    />
-                  </g>
-                  <g id="head">
-                    <path
-                      d="M86 72 L66 40 L102 56 Z"
-                      fill="url(#furMain)"
-                      stroke="#1f2230"
-                      stroke-width="4"
-                      stroke-linejoin="round"
-                    />
-                    <path
-                      d="M178 72 L198 40 L162 56 Z"
-                      fill="url(#furMain)"
-                      stroke="#1f2230"
-                      stroke-width="4"
-                      stroke-linejoin="round"
-                    />
-                    <path d="M86 72 L74 52 L100 62 Z" fill="url(#earInner)" opacity="0.75" />
-                    <path d="M178 72 L190 52 L164 62 Z" fill="url(#earInner)" opacity="0.75" />
-                    <path
-                      d="M74 124 C70 92 92 60 126 56 C162 52 194 78 194 116 C194 146 172 170 140 170 C108 170 84 150 74 124 Z"
-                      fill="url(#furMain)"
-                      stroke="#1f2230"
-                      stroke-width="4"
-                      stroke-linejoin="round"
-                    />
-                  </g>
-                  <g id="face">
-                    <circle
-                      id="faceMaskShape"
-                      cx="140"
-                      cy="128"
-                      r="54"
-                      fill="url(#faceMask)"
-                      stroke="rgba(255, 255, 255, 0.75)"
-                      stroke-width="3"
-                    />
-                    <g id="faceFeatures">
-                      <g id="eyesOpen">
-                        <ellipse id="eyeLeft" cx="120" cy="142" rx="20" ry="24" fill="#ffffff" opacity="0.95" />
-                        <ellipse id="eyeRight" cx="168" cy="142" rx="20" ry="24" fill="#ffffff" opacity="0.95" />
-                        <circle class="pupil" id="pupilLeft" cx="120" cy="146" r="9" fill="#0e1018" />
-                        <circle class="pupil" id="pupilRight" cx="168" cy="146" r="9" fill="#0e1018" />
-                        <circle cx="116" cy="140" r="3" fill="#ffffff" opacity="0.75" />
-                        <circle cx="164" cy="140" r="3" fill="#ffffff" opacity="0.75" />
+                <svg viewBox="0 0 96 104" role="img" aria-label="Gato virtual">
+                  <g id="catBody">
+                    <g id="tail">
+                      <rect x="12" y="60" width="12" height="28" fill="var(--outline)" />
+                      <rect x="16" y="64" width="8" height="20" fill="var(--fur-main)" />
+                      <rect x="16" y="64" width="8" height="6" fill="var(--fur-accent, var(--fur-main))" />
+                      <rect x="16" y="76" width="8" height="6" fill="var(--fur-accent, var(--fur-main))" />
+                      <rect x="16" y="84" width="8" height="4" fill="var(--belly)" />
+                    </g>
+                    <g id="torso">
+                      <rect x="16" y="56" width="64" height="36" fill="var(--outline)" />
+                      <rect x="20" y="60" width="56" height="28" fill="var(--fur-main)" />
+                      <rect x="20" y="60" width="56" height="4" fill="var(--fur-secondary, var(--fur-main))" />
+                      <rect x="32" y="66" width="32" height="18" fill="var(--belly)" />
+                      <rect x="24" y="70" width="8" height="6" fill="var(--fur-accent, var(--fur-main))" />
+                      <rect x="56" y="70" width="8" height="6" fill="var(--fur-accent, var(--fur-main))" />
+                      <rect x="32" y="84" width="32" height="4" fill="var(--belly)" />
+                    </g>
+                    <g id="legs">
+                      <g>
+                        <rect x="20" y="76" width="12" height="20" fill="var(--outline)" />
+                        <rect x="24" y="80" width="8" height="16" fill="var(--fur-main)" />
+                        <rect x="24" y="92" width="8" height="4" fill="var(--paw)" />
                       </g>
-                      <g id="eyesClosed" opacity="0">
-                        <path
-                          d="M102 142 Q120 136 138 142"
-                          fill="none"
-                          stroke="#1f2230"
-                          stroke-width="4"
-                          stroke-linecap="round"
-                        />
-                        <path
-                          d="M150 142 Q168 136 186 142"
-                          fill="none"
-                          stroke="#1f2230"
-                          stroke-width="4"
-                          stroke-linecap="round"
-                        />
+                      <g>
+                        <rect x="36" y="76" width="12" height="20" fill="var(--outline)" />
+                        <rect x="40" y="80" width="8" height="16" fill="var(--fur-main)" />
+                        <rect x="40" y="92" width="8" height="4" fill="var(--paw)" />
                       </g>
-                      <path
-                        id="nose"
-                        d="M132 140 L140 150 L148 140 Z"
-                        fill="#f3b7c9"
-                        stroke="#c67c8f"
-                        stroke-width="2"
-                        stroke-linejoin="round"
-                      />
-                      <path
-                        id="mouth"
-                        d="M130 164 Q144 176 158 164"
-                        fill="none"
-                        stroke="#c67c8f"
-                        stroke-width="4"
-                        stroke-linecap="round"
-                      />
-                      <circle cx="108" cy="158" r="9" fill="url(#cheekGradient)" opacity="0.65" />
-                      <circle cx="180" cy="158" r="9" fill="url(#cheekGradient)" opacity="0.65" />
-                      <g id="whiskers">
-                        <path
-                          d="M88 142 Q110 134 132 142"
-                          fill="none"
-                          stroke="#1f2230"
-                          stroke-width="3"
-                          stroke-linecap="round"
-                        />
-                        <path
-                          d="M88 154 Q110 148 132 156"
-                          fill="none"
-                          stroke="rgba(31, 34, 48, 0.55)"
-                          stroke-width="3"
-                          stroke-linecap="round"
-                        />
-                        <path
-                          d="M168 142 Q190 134 212 142"
-                          fill="none"
-                          stroke="#1f2230"
-                          stroke-width="3"
-                          stroke-linecap="round"
-                        />
-                        <path
-                          d="M168 154 Q190 148 212 156"
-                          fill="none"
-                          stroke="rgba(31, 34, 48, 0.55)"
-                          stroke-width="3"
-                          stroke-linecap="round"
-                        />
+                      <g>
+                        <rect x="52" y="76" width="12" height="20" fill="var(--outline)" />
+                        <rect x="56" y="80" width="8" height="16" fill="var(--fur-main)" />
+                        <rect x="56" y="92" width="8" height="4" fill="var(--paw)" />
+                      </g>
+                      <g>
+                        <rect x="68" y="76" width="12" height="20" fill="var(--outline)" />
+                        <rect x="72" y="80" width="8" height="16" fill="var(--fur-main)" />
+                        <rect x="72" y="84" width="8" height="4" fill="var(--fur-accent, var(--fur-main))" />
+                        <rect x="72" y="92" width="8" height="4" fill="var(--paw)" />
+                      </g>
+                    </g>
+                    <g id="head">
+                      <rect x="20" y="20" width="56" height="44" fill="var(--outline)" />
+                      <rect x="24" y="24" width="48" height="36" fill="var(--fur-main)" />
+                      <rect x="24" y="24" width="8" height="36" fill="var(--fur-secondary, var(--fur-main))" />
+                      <rect x="64" y="24" width="8" height="36" fill="var(--fur-secondary, var(--fur-main))" />
+                      <rect x="36" y="28" width="24" height="6" fill="var(--fur-accent, var(--fur-main))" />
+                      <rect x="36" y="36" width="24" height="4" fill="var(--fur-main)" />
+                      <rect x="28" y="44" width="8" height="6" fill="var(--fur-secondary, var(--fur-main))" />
+                      <rect x="60" y="44" width="8" height="6" fill="var(--fur-secondary, var(--fur-main))" />
+                      <rect x="24" y="52" width="48" height="6" fill="var(--fur-main)" />
+                      <g id="ears">
+                        <rect x="24" y="12" width="12" height="12" fill="var(--outline)" />
+                        <rect x="28" y="16" width="8" height="8" fill="var(--fur-secondary, var(--fur-main))" />
+                        <rect x="30" y="18" width="4" height="4" fill="var(--ear-inner)" />
+                        <rect x="60" y="12" width="12" height="12" fill="var(--outline)" />
+                        <rect x="64" y="16" width="8" height="8" fill="var(--fur-secondary, var(--fur-main))" />
+                        <rect x="66" y="18" width="4" height="4" fill="var(--ear-inner)" />
+                      </g>
+                      <g id="faceFeatures">
+                        <g id="eyesOpen">
+                          <rect x="32" y="36" width="10" height="10" fill="#f5f8ff" />
+                          <rect x="34" y="38" width="6" height="6" class="pupil" fill="var(--pupil)" />
+                          <rect x="34" y="38" width="2" height="2" fill="#ffffff" opacity="0.85" />
+                          <rect x="54" y="36" width="10" height="10" fill="#f5f8ff" />
+                          <rect x="56" y="38" width="6" height="6" class="pupil" fill="var(--pupil)" />
+                          <rect x="56" y="38" width="2" height="2" fill="#ffffff" opacity="0.85" />
+                        </g>
+                        <g id="eyesClosed" opacity="0">
+                          <rect x="32" y="40" width="10" height="2" fill="var(--outline)" />
+                          <rect x="54" y="40" width="10" height="2" fill="var(--outline)" />
+                        </g>
+                        <rect id="nose" x="46" y="46" width="4" height="4" fill="var(--nose, var(--ear-inner))" />
+                        <g id="mouth">
+                          <rect x="46" y="50" width="4" height="2" fill="var(--outline)" />
+                          <rect x="44" y="52" width="6" height="2" fill="var(--outline)" />
+                          <rect x="52" y="52" width="6" height="2" fill="var(--outline)" />
+                        </g>
+                        <rect x="28" y="50" width="6" height="4" fill="var(--cheek)" />
+                        <rect x="62" y="50" width="6" height="4" fill="var(--cheek)" />
+                        <g id="whiskers">
+                          <rect x="20" y="46" width="12" height="2" fill="var(--outline)" />
+                          <rect x="20" y="50" width="12" height="2" fill="var(--outline)" opacity="0.7" />
+                          <rect x="64" y="46" width="12" height="2" fill="var(--outline)" />
+                          <rect x="64" y="50" width="12" height="2" fill="var(--outline)" opacity="0.7" />
+                        </g>
                       </g>
                     </g>
                   </g>
                   <g id="accessory" opacity="0">
                     <path
-                      d="M96 176 C118 170 142 170 164 176 L156 194 C140 188 120 188 104 194 Z"
-                      fill="#6ee7ff"
-                      stroke="#4aa5ff"
-                      stroke-width="3"
-                      stroke-linejoin="round"
+                      d="M30 60 H66 V66 H54 V78 H42 V66 H30 Z"
+                      fill="var(--collar, #6ee7ff)"
+                      stroke="var(--collar-stroke, #4aa5ff)"
+                      stroke-width="1"
+                      stroke-linejoin="miter"
+                      vector-effect="non-scaling-stroke"
                     />
                   </g>
                   <g id="activityProps">
                     <g id="propBowl">
-                      <ellipse cx="140" cy="206" rx="44" ry="12" fill="#f7c27c" opacity="0.9" />
-                      <path
-                        d="M100 200 Q140 188 180 200 L174 216 Q140 226 106 216 Z"
-                        fill="#f4a261"
-                        stroke="#d6803a"
-                        stroke-width="3"
-                        stroke-linejoin="round"
-                      />
-                      <ellipse cx="140" cy="200" rx="40" ry="10" fill="#ffe6c6" opacity="0.9" />
+                      <rect x="30" y="86" width="36" height="8" fill="#f4a261" />
+                      <rect x="30" y="94" width="36" height="4" fill="#d6803a" />
+                      <rect x="34" y="82" width="28" height="4" fill="#ffe6c6" />
                     </g>
                     <g id="propYarn">
-                      <circle cx="92" cy="202" r="16" fill="#ff8ad9" stroke="#d15fa8" stroke-width="3" />
-                      <path
-                        d="M80 196 Q92 194 104 196"
-                        stroke="#d15fa8"
-                        stroke-width="2"
-                        fill="none"
-                      />
-                      <path
-                        d="M84 206 Q92 202 100 206"
-                        stroke="#d15fa8"
-                        stroke-width="2"
-                        fill="none"
-                      />
-                      <path
-                        d="M108 210 Q122 218 138 214"
-                        stroke="#d15fa8"
-                        stroke-width="2"
-                        fill="none"
-                        stroke-linecap="round"
-                      />
+                      <rect x="18" y="88" width="12" height="12" fill="#ff8ad9" />
+                      <rect x="14" y="92" width="6" height="4" fill="#d15fa8" />
+                      <rect x="22" y="84" width="8" height="4" fill="#d15fa8" />
+                      <rect x="30" y="92" width="12" height="2" fill="#d15fa8" />
                     </g>
                     <g id="propSleep">
-                      <text x="188" y="118" fill="#ffffff" font-family="'Press Start 2P', monospace" font-size="18">
-                        Z
-                      </text>
-                      <text x="204" y="94" fill="#ffffff" font-family="'Press Start 2P', monospace" font-size="14">
-                        Z
-                      </text>
-                      <text x="218" y="74" fill="#ffffff" font-family="'Press Start 2P', monospace" font-size="10">
-                        Z
-                      </text>
+                      <text x="74" y="32" fill="#ffffff" font-family="'Press Start 2P', monospace" font-size="10">Z</text>
+                      <text x="80" y="24" fill="#ffffff" font-family="'Press Start 2P', monospace" font-size="8">Z</text>
+                      <text x="84" y="18" fill="#ffffff" font-family="'Press Start 2P', monospace" font-size="6">Z</text>
                     </g>
                   </g>
                 </svg>
@@ -1350,14 +1256,6 @@
       const catWanderer = document.getElementById("catWanderer");
       const cat = document.getElementById("cat");
       const identityAvatar = document.getElementById("identityAvatar");
-      const gradientRefs = {
-        furMain: document.getElementById("furMain"),
-        furBelly: document.getElementById("furBelly"),
-        faceMask: document.getElementById("faceMask"),
-        tailGradient: document.getElementById("tailGradient"),
-        earInner: document.getElementById("earInner"),
-        cheekGradient: document.getElementById("cheekGradient"),
-      };
       const pupilElements = document.querySelectorAll(".pupil");
       const hungerBar = document.getElementById("hungerBar");
       const hungerValue = document.getElementById("hungerValue");
@@ -1382,12 +1280,17 @@
           name: "Lukis",
           emoji: "🐈‍⬛",
           colors: {
-            furMain: ["#4f5662", "#242832", "#0e1118"],
-            furBelly: ["#f4f7ff", "#d6dbea"],
-            faceMask: ["#ffffff", "#eef2f7"],
-            tailGradient: ["#505867", "#181c25"],
-            earInner: ["#ffd6e6", "#f1a7c5"],
-            cheekGradient: ["#ffd1dc", "#f9a6bf"],
+            furMain: "#2f2c3d",
+            furSecondary: "#262338",
+            furAccent: "#454058",
+            belly: "#d8dbe8",
+            earInner: "#f3adc9",
+            cheek: "#f48fbf",
+            outline: "#08050f",
+            paw: "#e8ecf7",
+            collar: "#6ee7ff",
+            collarStroke: "#4aa5ff",
+            nose: "#f3adc9",
             pupil: "#0e1018",
           },
         },
@@ -1396,12 +1299,17 @@
           name: "Arwen",
           emoji: "🐈",
           colors: {
-            furMain: ["#e0e5ef", "#b5bdc9", "#848d9c"],
-            furBelly: ["#ffffff", "#e8edf5"],
-            faceMask: ["#f4f7fb", "#dce2ec"],
-            tailGradient: ["#c7ceda", "#8f97a5"],
-            earInner: ["#ffe0ee", "#f5bcd4"],
-            cheekGradient: ["#ffd7e4", "#f7abc6"],
+            furMain: "#cbd5e0",
+            furSecondary: "#b3bcc8",
+            furAccent: "#e1e7ef",
+            belly: "#f5f8ff",
+            earInner: "#f5c3da",
+            cheek: "#f7a6c6",
+            outline: "#364154",
+            paw: "#ffffff",
+            collar: "#7ed8ff",
+            collarStroke: "#4a9bd4",
+            nose: "#f5c3da",
             pupil: "#1a1c26",
           },
         },
@@ -1410,12 +1318,17 @@
           name: "Iria",
           emoji: "🐈‍⬜",
           colors: {
-            furMain: ["#f8e8d3", "#e0c3a3", "#b88760"],
-            furBelly: ["#fff3e5", "#f1d6b6"],
-            faceMask: ["#a26a47", "#5d3923"],
-            tailGradient: ["#b88963", "#533726"],
-            earInner: ["#f9c6ad", "#e29a76"],
-            cheekGradient: ["#ffc7b2", "#f3997f"],
+            furMain: "#dca676",
+            furSecondary: "#c27e4d",
+            furAccent: "#f1c58d",
+            belly: "#f6e2c8",
+            earInner: "#f2a57f",
+            cheek: "#f79f86",
+            outline: "#5b3824",
+            paw: "#f8e6d5",
+            collar: "#ffce6d",
+            collarStroke: "#e39b3a",
+            nose: "#f2a57f",
             pupil: "#221510",
           },
         },
@@ -1608,27 +1521,30 @@
       initialize();
       setInterval(tick, tickInterval);
 
-      function setGradientStops(id, colors = []) {
-        const gradient = gradientRefs[id];
-        if (!gradient) return;
-        const stops = gradient.querySelectorAll("stop");
-        stops.forEach((stop, index) => {
-          if (colors[index]) {
-            stop.setAttribute("stop-color", colors[index]);
-          }
-        });
-      }
-
       function applyCatSkinVisuals(skin) {
         if (!skin) return;
-        setGradientStops("furMain", skin.colors.furMain);
-        setGradientStops("furBelly", skin.colors.furBelly);
-        setGradientStops("faceMask", skin.colors.faceMask);
-        setGradientStops("tailGradient", skin.colors.tailGradient);
-        setGradientStops("earInner", skin.colors.earInner);
-        setGradientStops("cheekGradient", skin.colors.cheekGradient);
-        if (skin.colors.pupil) {
-          pupilElements.forEach((pupil) => pupil.setAttribute("fill", skin.colors.pupil));
+        const palette = skin.colors || {};
+        const variableMap = {
+          furMain: "--fur-main",
+          furSecondary: "--fur-secondary",
+          furAccent: "--fur-accent",
+          belly: "--belly",
+          earInner: "--ear-inner",
+          cheek: "--cheek",
+          outline: "--outline",
+          paw: "--paw",
+          collar: "--collar",
+          collarStroke: "--collar-stroke",
+          nose: "--nose",
+        };
+        Object.entries(variableMap).forEach(([key, cssVar]) => {
+          if (palette[key]) {
+            cat.style.setProperty(cssVar, palette[key]);
+          }
+        });
+        if (palette.pupil) {
+          pupilElements.forEach((pupil) => pupil.setAttribute("fill", palette.pupil));
+          cat.style.setProperty("--pupil", palette.pupil);
         }
         if (identityAvatar) {
           identityAvatar.textContent = skin.emoji;


### PR DESCRIPTION
## Summary
- add crisp pixel art styling defaults and updated facial animations for the cat container
- redraw the cat, props, and accessory as a full-body pixel art sprite that matches the new aesthetic
- map skin palettes to CSS variables and update skin data so color swaps work with the pixel art assets

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0133a5344832b8b79f28e4241ef0a