### PR TITLE
Improve cat accessories and sleeping details

### DIFF
--- a/app.js
+++ b/app.js
@@ -1329,6 +1329,9 @@ function persistSkinProgress(skinId = getCurrentSkinId()) {
       const headGrad = ctx.createLinearGradient(-radius, -radius, radius, radius);
       headGrad.addColorStop(0, shiftColor(palette.furSecondary, 0.16));
       headGrad.addColorStop(1, shiftColor(palette.furMain, -0.14));
+      drawSleepingEar(radius * 0.16, -radius * 1.02, true);
+      drawSleepingEar(-radius * 0.78, -radius * 0.92, false);
+
       ctx.beginPath();
       ctx.arc(0, 0, radius, 0, Math.PI * 2);
       ctx.fillStyle = headGrad;
@@ -1728,6 +1731,68 @@ function persistSkinProgress(skinId = getCurrentSkinId()) {
         ctx.fill();
         ctx.globalAlpha = 1;
       }
+
+      ctx.beginPath();
+      ctx.moveTo(earWidth * 0.16, earHeight * 0.74);
+      ctx.quadraticCurveTo(earWidth * 0.38, earHeight * 0.28, earWidth * 0.58, earHeight * 0.46);
+      ctx.strokeStyle = "rgba(255, 255, 255, 0.28)";
+      ctx.lineWidth = Math.max(1, earWidth * 0.06);
+      ctx.lineCap = "round";
+      ctx.stroke();
+
+      ctx.beginPath();
+      ctx.moveTo(earWidth * 0.16, earHeight * 0.88);
+      ctx.quadraticCurveTo(earWidth * 0.4, earHeight * 0.72, earWidth * 0.62, earHeight * 0.82);
+      ctx.strokeStyle = "rgba(0, 0, 0, 0.18)";
+      ctx.lineWidth = Math.max(0.8, earWidth * 0.05);
+      ctx.lineCap = "round";
+      ctx.stroke();
+      ctx.restore();
+    }
+
+    function drawSleepingEar(offsetX, offsetY, mirrored = false) {
+      ctx.save();
+      ctx.translate(offsetX, offsetY);
+      if (mirrored) {
+        ctx.scale(-1, 1);
+      }
+      ctx.rotate(-0.2);
+      const earWidth = metrics.ear.width * 0.9;
+      const earHeight = metrics.ear.height * 0.8;
+      ctx.beginPath();
+      ctx.moveTo(0, earHeight * 0.96);
+      ctx.quadraticCurveTo(earWidth * 0.22, earHeight * 0.42, earWidth * 0.7, 0);
+      ctx.quadraticCurveTo(earWidth * 0.36, earHeight * 0.58, 0, earHeight * 0.96);
+      ctx.closePath();
+      const earColor = styleKey === "siamese" ? palette.patternMask || palette.furAccent : palette.furSecondary;
+      const earGrad = ctx.createLinearGradient(earWidth * 0.1, earHeight, earWidth * 0.78, earHeight * 0.12);
+      earGrad.addColorStop(0, shiftColor(earColor, 0.14));
+      earGrad.addColorStop(1, shiftColor(earColor, -0.16));
+      ctx.fillStyle = earGrad;
+      ctx.fill();
+
+      if (palette.earInner) {
+        ctx.beginPath();
+        ctx.moveTo(earWidth * 0.16, earHeight * 0.86);
+        ctx.quadraticCurveTo(earWidth * 0.42, earHeight * 0.4, earWidth * 0.58, earHeight * 0.74);
+        ctx.quadraticCurveTo(earWidth * 0.32, earHeight * 0.64, earWidth * 0.16, earHeight * 0.92);
+        ctx.closePath();
+        const innerGrad = ctx.createLinearGradient(earWidth * 0.12, earHeight * 0.95, earWidth * 0.6, earHeight * 0.25);
+        innerGrad.addColorStop(0, shiftColor(palette.earInner, -0.04));
+        innerGrad.addColorStop(1, shiftColor(palette.earInner, 0.18));
+        ctx.fillStyle = innerGrad;
+        ctx.globalAlpha = 0.88;
+        ctx.fill();
+        ctx.globalAlpha = 1;
+      }
+
+      ctx.beginPath();
+      ctx.moveTo(earWidth * 0.18, earHeight * 0.76);
+      ctx.quadraticCurveTo(earWidth * 0.4, earHeight * 0.3, earWidth * 0.6, earHeight * 0.52);
+      ctx.strokeStyle = "rgba(255, 255, 255, 0.28)";
+      ctx.lineWidth = Math.max(1, earWidth * 0.06);
+      ctx.lineCap = "round";
+      ctx.stroke();
       ctx.restore();
     }
 

--- a/styles.css
+++ b/styles.css
@@ -370,30 +370,70 @@
 
       #propBowl {
         background:
-          linear-gradient(to bottom, rgba(0, 0, 0, 0) 0 20%, rgba(0, 0, 0, 0.14) 20% 32%, rgba(0, 0, 0, 0) 32% 100%),
-          conic-gradient(from 180deg, #c86c3a 0deg 60deg, #f7b589 60deg 300deg, #c86c3a 300deg 360deg);
-        border-radius: 30% 30% 45% 45% / 40% 40% 55% 55%;
-        transform: translate(-50%, 20%) scale(0.92);
+          radial-gradient(circle at 50% 15%, rgba(255, 255, 255, 0.6), rgba(255, 255, 255, 0) 60%),
+          linear-gradient(180deg, #ffddb8 0%, #f7b16f 42%, #d67536 100%);
+        border-radius: 38% 38% 60% 60% / 55% 55% 38% 38%;
+        box-shadow:
+          inset 0 -8px 14px rgba(116, 47, 9, 0.18),
+          inset 0 6px 10px rgba(255, 255, 255, 0.4),
+          0 10px 16px rgba(148, 49, 0, 0.22);
+        transform: translate(-50%, 18%) scale(0.94);
+        overflow: visible;
+      }
+
+      #propBowl::before {
+        content: "";
+        position: absolute;
+        inset: 4% 12% auto;
+        height: 32%;
+        border-radius: 999px;
+        background: linear-gradient(180deg, rgba(255, 255, 255, 0.88), rgba(255, 255, 255, 0));
+        opacity: 0.9;
+      }
+
+      #propBowl::after {
+        content: "";
+        position: absolute;
+        inset: 32% 18% 12%;
+        border-radius: 60% 60% 55% 55% / 65% 65% 45% 45%;
+        background:
+          radial-gradient(circle at 40% 30%, rgba(255, 234, 205, 0.9) 0 45%, rgba(242, 167, 94, 0.9) 65%, rgba(173, 94, 42, 0.95) 100%),
+          repeating-radial-gradient(circle at 60% 70%, rgba(255, 255, 255, 0.18) 0 6%, rgba(255, 255, 255, 0) 6% 12%);
+        box-shadow: inset 0 -6px 10px rgba(108, 42, 0, 0.22);
       }
 
       #propYarn {
         background:
-          repeating-conic-gradient(#c64f8a 0deg 20deg, #ff7ebd 20deg 40deg);
+          radial-gradient(circle at 32% 24%, rgba(255, 236, 247, 0.65) 0 32%, rgba(255, 236, 247, 0) 68%),
+          repeating-conic-gradient(#c64f8a 0deg 18deg, #ff7ebd 18deg 36deg);
         border-radius: 50%;
-        box-shadow: inset -0.4vw 0.4vw 0 rgba(0, 0, 0, 0.12);
-        transform: translate(-65%, 8%) rotate(-12deg) scale(0.86);
+        box-shadow:
+          inset -6px 6px 0 rgba(78, 20, 53, 0.16),
+          inset 0 0 0 2px rgba(255, 255, 255, 0.12);
+        transform: translate(-65%, 6%) rotate(-12deg) scale(0.9);
+      }
+
+      #propYarn::before {
+        content: "";
+        position: absolute;
+        width: 70%;
+        height: 24%;
+        left: 68%;
+        top: 62%;
+        border-radius: 999px;
+        background: linear-gradient(90deg, rgba(255, 206, 238, 0.85), rgba(227, 119, 180, 0.6));
+        transform: rotate(18deg);
+        box-shadow: 0 4px 6px rgba(0, 0, 0, 0.16);
       }
 
       #propYarn::after {
         content: "";
         position: absolute;
-        width: 70%;
-        height: 14%;
-        top: 58%;
-        left: 46%;
-        border-radius: 999px;
-        background: rgba(255, 207, 238, 0.7);
-        transform: rotate(-12deg);
+        inset: 16% 18% 20% 20%;
+        border-radius: 50%;
+        background:
+          conic-gradient(from 120deg, rgba(255, 255, 255, 0.35) 0deg 40deg, rgba(255, 255, 255, 0) 40deg 110deg, rgba(255, 255, 255, 0.28) 110deg 140deg, rgba(255, 255, 255, 0) 140deg 360deg);
+        opacity: 0.85;
       }
 
       #propSleep {


### PR DESCRIPTION
## Summary
- refine the 2D cat ears with subtle shading details and render dedicated ears while the cat sleeps
- add a dedicated helper for sleeping ear rendering so the ears remain visible in nap animations
- redesign the food bowl and yarn CSS props with richer gradients, shadows and highlights for a more polished look

## Testing
- not run (static project)


------
https://chatgpt.com/codex/tasks/task_e_68d05ccd07f8832b883cda9e7e1faf87