### PR TITLE
Improve cat ear rendering and update cat names

### DIFF
--- a/app.js
+++ b/app.js
@@ -32,7 +32,7 @@ let lastMoodKey = null;
 const catSkins = [
   {
     id: "tuxedo",
-    name: "Tizón",
+    name: "Lukis",
     emoji: "🐈‍⬛",
     pattern: "tuxedo",
     colors: {
@@ -56,7 +56,7 @@ const catSkins = [
   },
   {
     id: "silver",
-    name: "Luna",
+    name: "Arwen",
     emoji: "🐈",
     pattern: "silver",
     colors: {
@@ -80,7 +80,7 @@ const catSkins = [
   },
   {
     id: "siamese",
-    name: "Suri",
+    name: "Iria",
     emoji: "🐱",
     pattern: "siamese",
     colors: {
@@ -1705,46 +1705,57 @@ function persistSkinProgress(skinId = getCurrentSkinId()) {
       }
       const earWidth = metrics.ear.width;
       const earHeight = metrics.ear.height;
+      const baseInset = earWidth * 0.22;
       ctx.beginPath();
-      ctx.moveTo(0, earHeight);
-      ctx.quadraticCurveTo(earWidth * 0.15, earHeight * 0.2, earWidth * 0.6, 0);
-      ctx.quadraticCurveTo(earWidth * 0.32, earHeight * 0.6, 0, earHeight);
+      ctx.moveTo(-baseInset, earHeight);
+      ctx.quadraticCurveTo(earWidth * 0.02, earHeight * 0.58, earWidth * 0.16, earHeight * 0.16);
+      ctx.quadraticCurveTo(earWidth * 0.38, -earHeight * 0.18, earWidth * 0.64, earHeight * 0.22);
+      ctx.quadraticCurveTo(earWidth * 0.48, earHeight * 0.74, earWidth * 0.08, earHeight * 1.0);
+      ctx.quadraticCurveTo(-baseInset * 0.1, earHeight * 0.92, -baseInset, earHeight);
       ctx.closePath();
       const earColor = styleKey === "siamese" ? palette.patternMask || palette.furAccent : palette.furSecondary;
-      const earGrad = ctx.createLinearGradient(0, earHeight, earWidth * 0.6, 0);
-      earGrad.addColorStop(0, shiftColor(earColor, 0.16));
-      earGrad.addColorStop(1, shiftColor(earColor, -0.14));
+      const earGrad = ctx.createLinearGradient(-baseInset * 0.6, earHeight, earWidth * 0.7, -earHeight * 0.05);
+      earGrad.addColorStop(0, shiftColor(earColor, 0.22));
+      earGrad.addColorStop(0.55, shiftColor(earColor, 0.02));
+      earGrad.addColorStop(1, shiftColor(earColor, -0.18));
       ctx.fillStyle = earGrad;
       ctx.fill();
 
+      ctx.strokeStyle = shiftColor(earColor, -0.28);
+      ctx.lineWidth = Math.max(0.9, earWidth * 0.05);
+      ctx.globalAlpha = 0.35;
+      ctx.stroke();
+      ctx.globalAlpha = 1;
+
       if (palette.earInner) {
         ctx.beginPath();
-        ctx.moveTo(earWidth * 0.12, earHeight * 0.88);
-        ctx.quadraticCurveTo(earWidth * 0.36, earHeight * 0.35, earWidth * 0.52, earHeight * 0.82);
-        ctx.quadraticCurveTo(earWidth * 0.28, earHeight * 0.65, earWidth * 0.12, earHeight * 0.88);
+        ctx.moveTo(-baseInset * 0.1, earHeight * 0.88);
+        ctx.quadraticCurveTo(earWidth * 0.18, earHeight * 0.48, earWidth * 0.34, earHeight * 0.22);
+        ctx.quadraticCurveTo(earWidth * 0.36, earHeight * 0.48, earWidth * 0.18, earHeight * 0.82);
+        ctx.quadraticCurveTo(earWidth * 0.06, earHeight * 0.96, -baseInset * 0.1, earHeight * 0.88);
         ctx.closePath();
-        const innerGrad = ctx.createLinearGradient(0, earHeight, earWidth * 0.5, earHeight * 0.2);
-        innerGrad.addColorStop(0, shiftColor(palette.earInner, -0.08));
-        innerGrad.addColorStop(1, shiftColor(palette.earInner, 0.14));
+        const innerGrad = ctx.createLinearGradient(-baseInset * 0.2, earHeight, earWidth * 0.52, earHeight * 0.18);
+        innerGrad.addColorStop(0, shiftColor(palette.earInner, -0.1));
+        innerGrad.addColorStop(1, shiftColor(palette.earInner, 0.18));
         ctx.fillStyle = innerGrad;
-        ctx.globalAlpha = 0.9;
+        ctx.globalAlpha = 0.92;
         ctx.fill();
         ctx.globalAlpha = 1;
       }
 
       ctx.beginPath();
-      ctx.moveTo(earWidth * 0.16, earHeight * 0.74);
-      ctx.quadraticCurveTo(earWidth * 0.38, earHeight * 0.28, earWidth * 0.58, earHeight * 0.46);
-      ctx.strokeStyle = "rgba(255, 255, 255, 0.28)";
-      ctx.lineWidth = Math.max(1, earWidth * 0.06);
+      ctx.moveTo(-baseInset * 0.2, earHeight * 0.9);
+      ctx.quadraticCurveTo(earWidth * 0.28, earHeight * 0.28, earWidth * 0.58, earHeight * 0.38);
+      ctx.strokeStyle = "rgba(255, 255, 255, 0.32)";
+      ctx.lineWidth = Math.max(0.8, earWidth * 0.045);
       ctx.lineCap = "round";
       ctx.stroke();
 
       ctx.beginPath();
-      ctx.moveTo(earWidth * 0.16, earHeight * 0.88);
-      ctx.quadraticCurveTo(earWidth * 0.4, earHeight * 0.72, earWidth * 0.62, earHeight * 0.82);
-      ctx.strokeStyle = "rgba(0, 0, 0, 0.18)";
-      ctx.lineWidth = Math.max(0.8, earWidth * 0.05);
+      ctx.moveTo(-baseInset * 0.15, earHeight * 0.98);
+      ctx.quadraticCurveTo(earWidth * 0.12, earHeight * 1.04, earWidth * 0.34, earHeight * 0.92);
+      ctx.strokeStyle = "rgba(0, 0, 0, 0.22)";
+      ctx.lineWidth = Math.max(0.7, earWidth * 0.038);
       ctx.lineCap = "round";
       ctx.stroke();
       ctx.restore();


### PR DESCRIPTION
## Summary
- rename the three available cat skins to Lukis, Arwen, and Iria
- redraw the ear geometry with richer shading and highlights for a cuter head silhouette

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d060b8a940832b94897ee9f82dc574