### PR TITLE
Add Sylvanian family mode and refresh UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,22 +43,108 @@
               aria-live="polite"
             >
               <span id="dayEmoji">🌞</span>
-              <span id="dayLabel">Parque soleado</span>
+              <span id="dayLabel" class="sr-only">Modo día</span>
             </div>
           </div>
-          <div class="scene" id="catScene">
-            <div class="scene-floor"></div>
-            <div class="cat-wanderer" id="catWanderer">
-              <div class="cat-shadow"></div>
-              <div class="cat" id="cat" data-mood="feliz" data-activity="idle" data-motion="idle">
-                <div class="cat-sprite" id="catSprite" role="img" aria-label="Gato virtual ilustrado">
-                  <canvas id="catSpriteCanvas" width="220" height="180" aria-hidden="true"></canvas>
-                  <div class="cat-accessory" id="accessory" aria-hidden="true"></div>
+          <nav class="mode-toggle" role="tablist" aria-label="Mundos disponibles">
+            <button
+              class="mode-toggle-button is-active"
+              type="button"
+              role="tab"
+              aria-selected="true"
+              data-mode="cat"
+              aria-controls="catScene"
+            >
+              Gatitos
+            </button>
+            <button
+              class="mode-toggle-button"
+              type="button"
+              role="tab"
+              aria-selected="false"
+              data-mode="family"
+              aria-controls="familyScene"
+            >
+              Sylvanians
+            </button>
+          </nav>
+          <div class="scene" id="virtualScene" data-active="cat">
+            <div class="stage stage-cat" id="catScene" aria-hidden="false">
+              <div class="scene-floor"></div>
+              <div class="cat-wanderer" id="catWanderer">
+                <div class="cat-shadow"></div>
+                <div class="cat" id="cat" data-mood="feliz" data-activity="idle" data-motion="idle">
+                  <div class="cat-sprite" id="catSprite" role="img" aria-label="Gato virtual ilustrado">
+                    <canvas id="catSpriteCanvas" width="220" height="180" aria-hidden="true"></canvas>
+                    <div class="cat-accessory" id="accessory" aria-hidden="true"></div>
+                  </div>
+                  <div class="activity-props" id="activityProps" aria-hidden="true">
+                    <div class="pixel-prop" id="propBowl"></div>
+                    <div class="pixel-prop" id="propYarn"></div>
+                    <div class="pixel-prop" id="propSleep">Z</div>
+                  </div>
                 </div>
-                <div class="activity-props" id="activityProps" aria-hidden="true">
-                  <div class="pixel-prop" id="propBowl"></div>
-                  <div class="pixel-prop" id="propYarn"></div>
-                  <div class="pixel-prop" id="propSleep">Z</div>
+              </div>
+            </div>
+            <div class="stage stage-family" id="familyScene" aria-hidden="true">
+              <div class="living-room">
+                <div class="living-room-wall"></div>
+                <div class="living-room-floor"></div>
+                <div class="family-props" id="familyProps" aria-hidden="true">
+                  <div class="family-prop" data-prop="snack"></div>
+                  <div class="family-prop" data-prop="play"></div>
+                  <div class="family-prop" data-prop="nap">Zz</div>
+                </div>
+                <div class="family-member" data-member="mama">
+                  <div class="sylvanian" aria-hidden="true">
+                    <div class="sylvanian-ears"></div>
+                    <div class="sylvanian-head">
+                      <span class="eye eye-left"></span>
+                      <span class="eye eye-right"></span>
+                      <span class="nose"></span>
+                      <span class="blush blush-left"></span>
+                      <span class="blush blush-right"></span>
+                    </div>
+                    <div class="sylvanian-body">
+                      <span class="outfit"></span>
+                      <span class="paws"></span>
+                    </div>
+                  </div>
+                  <span class="member-label">Mamá Arce</span>
+                </div>
+                <div class="family-member" data-member="papa">
+                  <div class="sylvanian" aria-hidden="true">
+                    <div class="sylvanian-ears"></div>
+                    <div class="sylvanian-head">
+                      <span class="eye eye-left"></span>
+                      <span class="eye eye-right"></span>
+                      <span class="nose"></span>
+                      <span class="blush blush-left"></span>
+                      <span class="blush blush-right"></span>
+                    </div>
+                    <div class="sylvanian-body">
+                      <span class="outfit"></span>
+                      <span class="paws"></span>
+                    </div>
+                  </div>
+                  <span class="member-label">Papá Arce</span>
+                </div>
+                <div class="family-member" data-member="peque">
+                  <div class="sylvanian" aria-hidden="true">
+                    <div class="sylvanian-ears"></div>
+                    <div class="sylvanian-head">
+                      <span class="eye eye-left"></span>
+                      <span class="eye eye-right"></span>
+                      <span class="nose"></span>
+                      <span class="blush blush-left"></span>
+                      <span class="blush blush-right"></span>
+                    </div>
+                    <div class="sylvanian-body">
+                      <span class="outfit"></span>
+                      <span class="paws"></span>
+                    </div>
+                  </div>
+                  <span class="member-label">Peque Arce</span>
                 </div>
               </div>
             </div>

--- a/styles.css
+++ b/styles.css
@@ -126,6 +126,18 @@
         box-shadow: 0 3px 0 rgba(255, 118, 197, 0.35);
       }
 
+      .identity-avatar.is-static,
+      .identity-avatar[disabled] {
+        cursor: default;
+        box-shadow: none;
+        opacity: 0.75;
+        transform: none;
+      }
+
+      .identity-avatar[disabled]:focus-visible {
+        outline: none;
+      }
+
       .identity-meta {
         display: flex;
         flex-direction: column;
@@ -219,6 +231,51 @@
         line-height: 1;
       }
 
+      .mode-toggle {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 8px;
+        padding: 8px;
+        margin-top: 4px;
+        border-radius: 18px;
+        background: rgba(255, 255, 255, 0.5);
+        border: 2px solid rgba(255, 255, 255, 0.65);
+        box-shadow: inset 0 0 12px rgba(255, 255, 255, 0.28);
+      }
+
+      .mode-toggle-button {
+        appearance: none;
+        border: none;
+        border-radius: 14px;
+        padding: 10px 12px 8px;
+        font: inherit;
+        font-size: 0.58rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        background: rgba(255, 255, 255, 0.55);
+        color: var(--text-secondary);
+        box-shadow: inset 0 -4px 0 rgba(255, 134, 201, 0.24);
+        transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+        cursor: pointer;
+      }
+
+      .mode-toggle-button.is-active {
+        background: linear-gradient(180deg, rgba(255, 214, 246, 0.9), rgba(255, 153, 210, 0.75));
+        box-shadow: inset 0 -6px 0 rgba(255, 118, 197, 0.35);
+        color: var(--text-primary);
+        transform: translateY(-1px);
+      }
+
+      .mode-toggle-button:focus-visible {
+        outline: 2px solid rgba(89, 148, 255, 0.8);
+        outline-offset: 3px;
+      }
+
+      .mode-toggle-button:active {
+        transform: translateY(2px);
+        box-shadow: inset 0 -3px 0 rgba(255, 118, 197, 0.38);
+      }
+
       .scene {
         position: relative;
         height: clamp(260px, 48vw, 320px);
@@ -226,6 +283,7 @@
         overflow: hidden;
         background: linear-gradient(180deg, rgba(255, 255, 255, 0.45) 0%, rgba(255, 255, 255, 0.05) 60%, transparent 100%);
         border: 2px dashed rgba(255, 255, 255, 0.4);
+        transition: background 0.4s ease, border-color 0.4s ease;
       }
 
       .scene::before,
@@ -248,6 +306,441 @@
         height: 160px;
         background: repeating-linear-gradient(0deg, rgba(255, 255, 255, 0.32) 0 2px, transparent 2px 8px);
         opacity: 0.5;
+      }
+
+      .scene[data-active="family"] {
+        background: linear-gradient(180deg, rgba(255, 238, 223, 0.95) 0%, rgba(255, 212, 173, 0.88) 55%, rgba(255, 188, 141, 0.85) 100%);
+        border: 2px solid rgba(255, 200, 161, 0.7);
+      }
+
+      .scene[data-active="family"]::before {
+        background: radial-gradient(circle at 30% 20%, rgba(255, 255, 255, 0.3), transparent 55%),
+          radial-gradient(circle at 70% 18%, rgba(255, 255, 255, 0.35), transparent 50%);
+        opacity: 0.35;
+      }
+
+      .scene[data-active="family"]::after {
+        opacity: 0;
+      }
+
+      .stage {
+        position: absolute;
+        inset: 0;
+        padding: 0;
+        transition: opacity 0.45s ease;
+      }
+
+      .stage-cat {
+        position: absolute;
+        inset: 0;
+      }
+
+      .stage-family {
+        opacity: 0;
+        pointer-events: none;
+        display: flex;
+        align-items: stretch;
+        justify-content: center;
+      }
+
+      .scene[data-active="family"] .stage-cat {
+        opacity: 0;
+        pointer-events: none;
+      }
+
+      .scene[data-active="family"] .stage-family {
+        opacity: 1;
+        pointer-events: auto;
+      }
+
+      .living-room {
+        position: relative;
+        width: 100%;
+        height: 100%;
+        padding: 20px 22px 28px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .living-room-wall {
+        position: absolute;
+        inset: 0 0 34%;
+        background: linear-gradient(180deg, rgba(255, 248, 242, 0.95) 0%, rgba(255, 226, 210, 0.95) 65%, rgba(255, 210, 190, 0.92) 100%);
+        border-bottom: 3px solid rgba(255, 189, 156, 0.75);
+        box-shadow: inset 0 20px 28px rgba(255, 180, 190, 0.18);
+      }
+
+      .living-room-floor {
+        position: absolute;
+        inset: auto 0 0;
+        height: 38%;
+        background: linear-gradient(120deg, rgba(255, 201, 164, 0.95), rgba(240, 167, 118, 0.95));
+        border-top: 3px solid rgba(255, 220, 196, 0.75);
+        box-shadow: inset 0 16px 20px rgba(156, 82, 34, 0.22);
+      }
+
+      .living-room::after {
+        content: "";
+        position: absolute;
+        inset: 12% 18% auto;
+        height: 2px;
+        background: linear-gradient(90deg, rgba(255, 255, 255, 0.6), rgba(255, 170, 120, 0.4), rgba(255, 255, 255, 0.6));
+        opacity: 0.7;
+      }
+
+      .family-props {
+        position: absolute;
+        inset: auto 0 16%;
+        width: 100%;
+        display: flex;
+        align-items: flex-end;
+        justify-content: center;
+        gap: 18px;
+        pointer-events: none;
+      }
+
+      .family-prop {
+        width: clamp(68px, 20vw, 110px);
+        height: clamp(44px, 10vw, 64px);
+        border-radius: 16px;
+        opacity: 0;
+        transform: translateY(16px) scale(0.92);
+        transition: opacity 0.3s ease, transform 0.3s ease;
+      }
+
+      .family-prop[data-prop="snack"] {
+        background: linear-gradient(180deg, rgba(255, 244, 236, 0.92), rgba(255, 206, 173, 0.92));
+        border: 2px solid rgba(255, 183, 135, 0.7);
+        box-shadow: inset 0 6px 10px rgba(255, 255, 255, 0.6), inset 0 -6px 12px rgba(173, 96, 42, 0.15);
+        position: relative;
+      }
+
+      .family-prop[data-prop="snack"]::before,
+      .family-prop[data-prop="snack"]::after {
+        content: "";
+        position: absolute;
+        top: 20%;
+        width: 26%;
+        height: 36%;
+        border-radius: 999px;
+        background: radial-gradient(circle at 40% 30%, rgba(255, 182, 182, 0.9), rgba(255, 134, 134, 0.8));
+        box-shadow: inset 0 4px 6px rgba(255, 255, 255, 0.6);
+      }
+
+      .family-prop[data-prop="snack"]::before {
+        left: 22%;
+      }
+
+      .family-prop[data-prop="snack"]::after {
+        right: 22%;
+      }
+
+      .family-prop[data-prop="play"] {
+        background:
+          linear-gradient(120deg, rgba(255, 255, 255, 0.8), rgba(255, 200, 232, 0.9)),
+          repeating-linear-gradient(45deg, rgba(255, 154, 206, 0.55) 0 8px, rgba(152, 209, 255, 0.6) 8px 16px);
+        border: 2px solid rgba(177, 130, 255, 0.5);
+        box-shadow: inset 0 8px 14px rgba(255, 255, 255, 0.6), inset 0 -10px 14px rgba(140, 90, 255, 0.2);
+        position: relative;
+      }
+
+      .family-prop[data-prop="play"]::before {
+        content: "";
+        position: absolute;
+        width: 28%;
+        height: 46%;
+        background: radial-gradient(circle at 50% 50%, rgba(255, 238, 255, 0.95), rgba(196, 107, 238, 0.75));
+        border-radius: 999px;
+        top: 24%;
+        left: 20%;
+        box-shadow: 0 6px 10px rgba(147, 95, 209, 0.3);
+      }
+
+      .family-prop[data-prop="play"]::after {
+        content: "";
+        position: absolute;
+        width: 26%;
+        height: 32%;
+        background: radial-gradient(circle at 50% 50%, rgba(229, 245, 255, 0.95), rgba(107, 187, 238, 0.7));
+        border-radius: 16px;
+        bottom: 18%;
+        right: 18%;
+        box-shadow: 0 6px 10px rgba(84, 148, 209, 0.22);
+      }
+
+      .family-prop[data-prop="nap"] {
+        font-family: "Press Start 2P", system-ui;
+        font-size: clamp(0.58rem, 2.2vw, 0.86rem);
+        letter-spacing: 0.28em;
+        color: rgba(136, 90, 196, 0.85);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: rgba(255, 244, 255, 0.85);
+        border: 2px solid rgba(173, 140, 255, 0.45);
+        box-shadow: inset 0 8px 14px rgba(255, 255, 255, 0.6);
+      }
+
+      .scene[data-active="family"] #familyScene[data-activity="feed"] .family-prop[data-prop="snack"],
+      .scene[data-active="family"] #familyScene[data-activity="play"] .family-prop[data-prop="play"],
+      .scene[data-active="family"] #familyScene[data-activity="nap"] .family-prop[data-prop="nap"] {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+      }
+
+      .family-member {
+        --base-x: 0px;
+        --base-scale: 1;
+        position: absolute;
+        bottom: 62px;
+        left: 50%;
+        transform: translate(calc(-50% + var(--base-x) + var(--x, 0px)), calc(var(--y, 0px))) scale(var(--scale, var(--base-scale)));
+        transform-origin: center bottom;
+        transition: transform 2.8s cubic-bezier(0.25, 0.8, 0.42, 1);
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 6px;
+        pointer-events: none;
+      }
+
+      .family-member[data-member="mama"] {
+        --base-x: -110px;
+        --base-scale: 1.05;
+        --fur: #f6e6d8;
+        --fur-dark: #e6cbb4;
+        --ear: #f8c6d6;
+        --blush: rgba(255, 164, 187, 0.85);
+        --outfit: #f592b6;
+        --outfit-accent: #ffe5f1;
+      }
+
+      .family-member[data-member="papa"] {
+        --base-x: 120px;
+        --base-scale: 1.02;
+        --fur: #f3e8d2;
+        --fur-dark: #d6c2a6;
+        --ear: #f3b8a6;
+        --blush: rgba(255, 177, 160, 0.8);
+        --outfit: #7ab4e3;
+        --outfit-accent: #e4f2ff;
+      }
+
+      .family-member[data-member="peque"] {
+        --base-x: 0px;
+        --base-scale: 0.92;
+        --fur: #fdf0dc;
+        --fur-dark: #e8cfaf;
+        --ear: #ffc6d6;
+        --blush: rgba(255, 194, 189, 0.85);
+        --outfit: #ffd87b;
+        --outfit-accent: #fff7d1;
+      }
+
+      .member-label {
+        font-family: "Press Start 2P", system-ui;
+        font-size: clamp(0.44rem, 1.6vw, 0.62rem);
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: rgba(116, 58, 38, 0.8);
+        background: rgba(255, 255, 255, 0.78);
+        border-radius: 8px;
+        padding: 4px 6px 3px;
+        border: 1px solid rgba(210, 160, 110, 0.45);
+        box-shadow: 0 4px 10px rgba(137, 78, 42, 0.16);
+      }
+
+      .sylvanian {
+        position: relative;
+        width: clamp(72px, 18vw, 112px);
+        aspect-ratio: 3 / 4.4;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: flex-end;
+      }
+
+      .sylvanian-ears {
+        position: absolute;
+        top: -8%;
+        left: 50%;
+        width: 64%;
+        height: 34%;
+        transform: translateX(-50%);
+      }
+
+      .sylvanian-ears::before,
+      .sylvanian-ears::after {
+        content: "";
+        position: absolute;
+        width: 44%;
+        height: 100%;
+        background: var(--fur, #f6e6d8);
+        border-radius: 60% 60% 45% 45% / 80% 80% 40% 40%;
+        box-shadow: inset 0 -6px 10px rgba(0, 0, 0, 0.08);
+      }
+
+      .sylvanian-ears::before {
+        left: 0;
+        transform: rotate(-6deg);
+      }
+
+      .sylvanian-ears::after {
+        right: 0;
+        transform: rotate(6deg);
+      }
+
+      .sylvanian-ears::before,
+      .sylvanian-ears::after {
+        background: linear-gradient(180deg, var(--ear, #f8c6d6) 0%, var(--fur, #f6e6d8) 78%);
+      }
+
+      .sylvanian-head {
+        position: relative;
+        width: 78%;
+        height: 48%;
+        background: radial-gradient(circle at 50% 36%, rgba(255, 255, 255, 0.75), transparent 62%), var(--fur, #f6e6d8);
+        border-radius: 70% 70% 68% 68%;
+        box-shadow: inset 0 -10px 12px rgba(0, 0, 0, 0.08);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .sylvanian-head .eye {
+        position: absolute;
+        width: 16%;
+        height: 24%;
+        background: radial-gradient(circle at 40% 40%, rgba(255, 255, 255, 0.75), rgba(36, 26, 31, 0.92));
+        border-radius: 50%;
+        top: 38%;
+        box-shadow: 0 2px 0 rgba(0, 0, 0, 0.12);
+      }
+
+      .sylvanian-head .eye-left {
+        left: 26%;
+      }
+
+      .sylvanian-head .eye-right {
+        right: 26%;
+      }
+
+      .sylvanian-head .nose {
+        position: absolute;
+        top: 54%;
+        left: 50%;
+        width: 18%;
+        height: 18%;
+        transform: translateX(-50%);
+        background: radial-gradient(circle, rgba(126, 77, 60, 0.8), rgba(58, 34, 24, 0.9));
+        border-radius: 45% 45% 55% 55%;
+        box-shadow: 0 2px 0 rgba(255, 255, 255, 0.45);
+      }
+
+      .sylvanian-head .blush {
+        position: absolute;
+        width: 26%;
+        height: 22%;
+        background: var(--blush, rgba(255, 170, 180, 0.8));
+        border-radius: 50%;
+        bottom: 14%;
+        opacity: 0.8;
+        filter: blur(1px);
+      }
+
+      .sylvanian-head .blush-left {
+        left: 14%;
+      }
+
+      .sylvanian-head .blush-right {
+        right: 14%;
+      }
+
+      .sylvanian-body {
+        position: relative;
+        width: 86%;
+        height: 52%;
+        background: var(--fur, #f6e6d8);
+        border-radius: 65% 65% 40% 40% / 55% 55% 45% 45%;
+        box-shadow: inset 0 -12px 16px rgba(0, 0, 0, 0.1);
+        display: flex;
+        align-items: flex-end;
+        justify-content: center;
+        padding-bottom: 14%;
+      }
+
+      .sylvanian-body .outfit {
+        position: absolute;
+        inset: 32% 12% 0;
+        background: linear-gradient(180deg, var(--outfit-accent, #ffe5f1) 0%, var(--outfit, #f592b6) 48%, var(--outfit, #f592b6) 100%);
+        border-radius: 55% 55% 38% 38% / 60% 60% 40% 40%;
+        box-shadow: inset 0 -8px 12px rgba(0, 0, 0, 0.12);
+      }
+
+      .sylvanian-body .outfit::before {
+        content: "";
+        position: absolute;
+        inset: 8% 18% auto;
+        height: 24%;
+        border-radius: 999px;
+        background: linear-gradient(90deg, rgba(255, 255, 255, 0.85), rgba(255, 210, 232, 0.7));
+        opacity: 0.9;
+      }
+
+      .sylvanian-body .paws {
+        position: absolute;
+        inset: auto 12% -8%;
+        height: 32%;
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-end;
+      }
+
+      .sylvanian-body .paws::before,
+      .sylvanian-body .paws::after {
+        content: "";
+        width: 34%;
+        height: 70%;
+        border-radius: 0 0 18px 18px;
+        background: linear-gradient(180deg, var(--fur, #f6e6d8), var(--fur-dark, #e6cbb4));
+        box-shadow: inset 0 -6px 10px rgba(0, 0, 0, 0.1);
+      }
+
+      .scene[data-active="family"] #familyScene[data-activity="play"] .family-member {
+        --scale: calc(var(--base-scale) * 1.04);
+      }
+
+      .scene[data-active="family"] #familyScene[data-activity="feed"] .family-member {
+        animation: familyBounce 1.6s ease-in-out infinite;
+      }
+
+      .scene[data-active="family"] #familyScene[data-activity="nap"] .family-member {
+        animation: familySway 2.6s ease-in-out infinite;
+      }
+
+      @keyframes familyBounce {
+        0%,
+        100% {
+          transform: translate(calc(-50% + var(--base-x) + var(--x, 0px)), calc(var(--y, 0px))) scale(var(--scale, var(--base-scale)));
+        }
+        50% {
+          transform: translate(calc(-50% + var(--base-x) + var(--x, 0px)), calc(var(--y, 0px) - 8px))
+            scale(calc(var(--scale, var(--base-scale)) * 1.02));
+        }
+      }
+
+      @keyframes familySway {
+        0% {
+          transform: translate(calc(-50% + var(--base-x) + var(--x, 0px)), calc(var(--y, 0px))) scale(var(--scale, var(--base-scale)));
+        }
+        50% {
+          transform: translate(calc(-50% + var(--base-x) + var(--x, 0px) + 4px), calc(var(--y, 0px) - 6px))
+            scale(calc(var(--scale, var(--base-scale)) * 0.99));
+        }
+        100% {
+          transform: translate(calc(-50% + var(--base-x) + var(--x, 0px)), calc(var(--y, 0px))) scale(var(--scale, var(--base-scale)));
+        }
       }
 
       .scene-floor {
@@ -369,71 +862,76 @@
       }
 
       #propBowl {
-        background:
-          radial-gradient(circle at 50% 15%, rgba(255, 255, 255, 0.6), rgba(255, 255, 255, 0) 60%),
-          linear-gradient(180deg, #ffddb8 0%, #f7b16f 42%, #d67536 100%);
-        border-radius: 38% 38% 60% 60% / 55% 55% 38% 38%;
+        width: 34%;
+        aspect-ratio: 5 / 3.2;
+        background: linear-gradient(180deg, #ffe9d4 0%, #f8c18b 52%, #e1843d 100%);
+        border-radius: 48% 48% 58% 58% / 70% 70% 44% 44%;
         box-shadow:
-          inset 0 -8px 14px rgba(116, 47, 9, 0.18),
-          inset 0 6px 10px rgba(255, 255, 255, 0.4),
-          0 10px 16px rgba(148, 49, 0, 0.22);
-        transform: translate(-50%, 18%) scale(0.94);
+          inset 0 -12px 18px rgba(125, 52, 12, 0.24),
+          inset 0 8px 12px rgba(255, 255, 255, 0.62),
+          0 14px 20px rgba(140, 62, 16, 0.22);
+        transform: translate(-50%, 22%) scale(0.94);
         overflow: visible;
       }
 
       #propBowl::before {
         content: "";
         position: absolute;
-        inset: 4% 12% auto;
-        height: 32%;
+        inset: 6% 10% auto;
+        height: 36%;
         border-radius: 999px;
-        background: linear-gradient(180deg, rgba(255, 255, 255, 0.88), rgba(255, 255, 255, 0));
-        opacity: 0.9;
+        background: linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.08));
+        box-shadow: 0 6px 10px rgba(255, 255, 255, 0.45);
       }
 
       #propBowl::after {
         content: "";
         position: absolute;
-        inset: 32% 18% 12%;
-        border-radius: 60% 60% 55% 55% / 65% 65% 45% 45%;
+        inset: 30% 18% 16%;
+        border-radius: 60% 60% 52% 52% / 68% 68% 42% 42%;
         background:
-          radial-gradient(circle at 40% 30%, rgba(255, 234, 205, 0.9) 0 45%, rgba(242, 167, 94, 0.9) 65%, rgba(173, 94, 42, 0.95) 100%),
-          repeating-radial-gradient(circle at 60% 70%, rgba(255, 255, 255, 0.18) 0 6%, rgba(255, 255, 255, 0) 6% 12%);
-        box-shadow: inset 0 -6px 10px rgba(108, 42, 0, 0.22);
+          radial-gradient(circle at 22% 42%, rgba(255, 234, 204, 0.95) 0 46%, transparent 47%),
+          radial-gradient(circle at 78% 38%, rgba(255, 234, 204, 0.95) 0 46%, transparent 47%),
+          radial-gradient(circle at 50% 50%, rgba(250, 143, 94, 0.85) 0 30%, transparent 32%),
+          radial-gradient(circle at 52% 64%, rgba(255, 187, 125, 0.85) 0 42%, transparent 44%),
+          repeating-linear-gradient(45deg, rgba(255, 255, 255, 0.16) 0 4px, rgba(255, 255, 255, 0) 4px 8px);
+        box-shadow: inset 0 -8px 12px rgba(145, 72, 24, 0.24);
       }
 
       #propYarn {
         background:
-          radial-gradient(circle at 32% 24%, rgba(255, 236, 247, 0.65) 0 32%, rgba(255, 236, 247, 0) 68%),
-          repeating-conic-gradient(#c64f8a 0deg 18deg, #ff7ebd 18deg 36deg);
+          radial-gradient(circle at 30% 28%, rgba(255, 246, 254, 0.85) 0 36%, rgba(255, 246, 254, 0) 68%),
+          conic-gradient(from 140deg, #f672b5 0 70deg, #c94f94 70deg 140deg, #ff8ac8 140deg 210deg, #bf4a86 210deg 360deg);
         border-radius: 50%;
         box-shadow:
-          inset -6px 6px 0 rgba(78, 20, 53, 0.16),
-          inset 0 0 0 2px rgba(255, 255, 255, 0.12);
-        transform: translate(-65%, 6%) rotate(-12deg) scale(0.9);
+          inset -8px 8px 0 rgba(90, 22, 70, 0.18),
+          inset 0 0 0 3px rgba(255, 255, 255, 0.22),
+          0 14px 18px rgba(106, 32, 84, 0.2);
+        transform: translate(-60%, 6%) rotate(-16deg) scale(0.92);
       }
 
       #propYarn::before {
         content: "";
         position: absolute;
-        width: 70%;
-        height: 24%;
-        left: 68%;
+        width: 82%;
+        height: 26%;
+        left: 76%;
         top: 62%;
         border-radius: 999px;
-        background: linear-gradient(90deg, rgba(255, 206, 238, 0.85), rgba(227, 119, 180, 0.6));
+        background: linear-gradient(90deg, rgba(255, 207, 238, 0.82), rgba(214, 103, 170, 0.65));
         transform: rotate(18deg);
-        box-shadow: 0 4px 6px rgba(0, 0, 0, 0.16);
+        box-shadow: 0 6px 10px rgba(78, 20, 53, 0.22);
       }
 
       #propYarn::after {
         content: "";
         position: absolute;
-        inset: 16% 18% 20% 20%;
+        inset: 18% 20% 20% 18%;
         border-radius: 50%;
         background:
-          conic-gradient(from 120deg, rgba(255, 255, 255, 0.35) 0deg 40deg, rgba(255, 255, 255, 0) 40deg 110deg, rgba(255, 255, 255, 0.28) 110deg 140deg, rgba(255, 255, 255, 0) 140deg 360deg);
-        opacity: 0.85;
+          conic-gradient(from 100deg, rgba(255, 255, 255, 0.38) 0deg 44deg, rgba(255, 255, 255, 0) 44deg 120deg, rgba(255, 255, 255, 0.3) 120deg 160deg, rgba(255, 255, 255, 0) 160deg 360deg),
+          repeating-conic-gradient(from 0deg, rgba(255, 178, 215, 0.55) 0deg 12deg, rgba(255, 178, 215, 0) 12deg 24deg);
+        opacity: 0.9;
       }
 
       #propSleep {
@@ -463,20 +961,20 @@
       @keyframes bowlBounce {
         0%,
         100% {
-          transform: translate(-50%, 20%) scale(0.92);
+          transform: translate(-50%, 22%) scale(0.94);
         }
         50% {
-          transform: translate(-50%, 12%) scale(1);
+          transform: translate(-50%, 12%) scale(1.04);
         }
       }
 
       @keyframes yarnBounce {
         0%,
         100% {
-          transform: translate(-65%, 8%) rotate(-12deg) scale(0.86);
+          transform: translate(-60%, 6%) rotate(-16deg) scale(0.92);
         }
         50% {
-          transform: translate(-68%, -4%) rotate(6deg) scale(0.95);
+          transform: translate(-62%, -6%) rotate(8deg) scale(1.02);
         }
       }
 
@@ -722,8 +1220,8 @@
       .toast {
         position: fixed;
         left: 50%;
-        bottom: 24px;
-        transform: translate(-50%, 120%);
+        top: 24px;
+        transform: translate(-50%, -160%);
         background: rgba(255, 255, 255, 0.92);
         color: var(--text-primary);
         border-radius: 18px;
@@ -791,6 +1289,36 @@
 
       body[data-mode="night"] .cat-shadow {
         background: rgba(6, 2, 30, 0.4);
+      }
+
+      body[data-mode="night"] .scene[data-active="family"] {
+        background: linear-gradient(180deg, rgba(78, 56, 126, 0.92) 0%, rgba(82, 62, 140, 0.92) 55%, rgba(70, 48, 128, 0.9) 100%);
+        border-color: rgba(156, 140, 255, 0.55);
+      }
+
+      body[data-mode="night"] .scene[data-active="family"]::before {
+        background: radial-gradient(circle at 28% 20%, rgba(255, 255, 255, 0.25), transparent 55%),
+          radial-gradient(circle at 72% 18%, rgba(183, 169, 255, 0.35), transparent 50%);
+        opacity: 0.4;
+      }
+
+      body[data-mode="night"] .living-room-wall {
+        background: linear-gradient(180deg, rgba(88, 67, 138, 0.92) 0%, rgba(74, 54, 128, 0.92) 70%, rgba(62, 44, 114, 0.9) 100%);
+        border-bottom-color: rgba(132, 116, 220, 0.65);
+        box-shadow: inset 0 18px 30px rgba(48, 30, 92, 0.5);
+      }
+
+      body[data-mode="night"] .living-room-floor {
+        background: linear-gradient(120deg, rgba(112, 82, 186, 0.85), rgba(92, 66, 162, 0.92));
+        border-top-color: rgba(170, 152, 255, 0.6);
+        box-shadow: inset 0 20px 24px rgba(36, 18, 74, 0.35);
+      }
+
+      body[data-mode="night"] .member-label {
+        color: rgba(236, 224, 255, 0.85);
+        background: rgba(56, 40, 110, 0.78);
+        border-color: rgba(146, 130, 234, 0.55);
+        box-shadow: 0 6px 14px rgba(22, 12, 56, 0.42);
       }
 
 


### PR DESCRIPTION
## Summary
- add a mode selector and living room scene featuring a Sylvanian family with independent stats and actions
- refresh cat props, toast placement, and environment indicator to rely on iconography only
- refactor state handling to support switching between cat and family, including separate logs, wandering, and mood updates

## Testing
- No automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d06e0ca9b8832b8bf555e62b72da1e