### PR TITLE
Replace binary PWA icons with SVG assets

### DIFF
--- a/icons/icon-192.svg
+++ b/icons/icon-192.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192">
+  <rect width="192" height="192" rx="36" fill="#ff85c5" />
+  <g transform="translate(32 32)">
+    <path d="M16 20 L32 0 L48 20" fill="#ffb6e6" />
+    <path d="M64 20 L80 0 L96 20" fill="#ffb6e6" />
+    <path d="M16 20 Q8 40 8 60 Q8 104 64 104 Q120 104 120 60 Q120 40 112 20" fill="#ffe1f4" />
+    <ellipse cx="44" cy="60" rx="10" ry="12" fill="#4b2f4f" />
+    <ellipse cx="84" cy="60" rx="10" ry="12" fill="#4b2f4f" />
+    <circle cx="44" cy="58" r="4" fill="#ffe1f4" />
+    <circle cx="84" cy="58" r="4" fill="#ffe1f4" />
+    <path d="M64 80 Q56 88 64 96 Q72 88 64 80" fill="#f78fb3" />
+    <path d="M44 86 Q52 90 60 86" stroke="#4b2f4f" stroke-width="3" stroke-linecap="round" fill="none" />
+    <path d="M84 86 Q76 90 68 86" stroke="#4b2f4f" stroke-width="3" stroke-linecap="round" fill="none" />
+    <path d="M24 74 Q16 72 12 66" stroke="#4b2f4f" stroke-width="3" stroke-linecap="round" fill="none" />
+    <path d="M24 80 Q16 82 10 88" stroke="#4b2f4f" stroke-width="3" stroke-linecap="round" fill="none" />
+    <path d="M104 74 Q112 72 116 66" stroke="#4b2f4f" stroke-width="3" stroke-linecap="round" fill="none" />
+    <path d="M104 80 Q112 82 118 88" stroke="#4b2f4f" stroke-width="3" stroke-linecap="round" fill="none" />
+    <circle cx="64" cy="74" r="6" fill="#f78fb3" stroke="#4b2f4f" stroke-width="2" />
+  </g>
+</svg>

--- a/icons/icon-512.svg
+++ b/icons/icon-512.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="96" fill="#ff85c5" />
+  <g transform="translate(96 96) scale(3)">
+    <path d="M16 20 L32 0 L48 20" fill="#ffb6e6" />
+    <path d="M64 20 L80 0 L96 20" fill="#ffb6e6" />
+    <path d="M16 20 Q8 40 8 60 Q8 104 64 104 Q120 104 120 60 Q120 40 112 20" fill="#ffe1f4" />
+    <ellipse cx="44" cy="60" rx="10" ry="12" fill="#4b2f4f" />
+    <ellipse cx="84" cy="60" rx="10" ry="12" fill="#4b2f4f" />
+    <circle cx="44" cy="58" r="4" fill="#ffe1f4" />
+    <circle cx="84" cy="58" r="4" fill="#ffe1f4" />
+    <path d="M64 80 Q56 88 64 96 Q72 88 64 80" fill="#f78fb3" />
+    <path d="M44 86 Q52 90 60 86" stroke="#4b2f4f" stroke-width="3" stroke-linecap="round" fill="none" />
+    <path d="M84 86 Q76 90 68 86" stroke="#4b2f4f" stroke-width="3" stroke-linecap="round" fill="none" />
+    <path d="M24 74 Q16 72 12 66" stroke="#4b2f4f" stroke-width="3" stroke-linecap="round" fill="none" />
+    <path d="M24 80 Q16 82 10 88" stroke="#4b2f4f" stroke-width="3" stroke-linecap="round" fill="none" />
+    <path d="M104 74 Q112 72 116 66" stroke="#4b2f4f" stroke-width="3" stroke-linecap="round" fill="none" />
+    <path d="M104 80 Q112 82 118 88" stroke="#4b2f4f" stroke-width="3" stroke-linecap="round" fill="none" />
+    <circle cx="64" cy="74" r="6" fill="#f78fb3" stroke="#4b2f4f" stroke-width="2" />
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#ff85c5" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <title>Catagotchi · Cuida a tu gato virtual</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -10,6 +14,9 @@
       href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=Poppins:wght@400;600;700&display=swap"
       rel="stylesheet"
     />
+    <link rel="manifest" href="manifest.webmanifest" />
+    <link rel="icon" type="image/svg+xml" href="icons/icon-192.svg" />
+    <link rel="apple-touch-icon" href="icons/icon-512.svg" />
     <link rel="stylesheet" href="styles.css" />
 
   </head>
@@ -45,6 +52,9 @@
               <span id="dayEmoji">🌞</span>
               <span id="dayLabel" class="sr-only">Modo día</span>
             </div>
+            <button class="install-chip" id="installButton" type="button" hidden aria-label="Instalar Catagotchi">
+              ⬇️ Instalar
+            </button>
           </div>
           <nav class="mode-toggle" role="tablist" aria-label="Mundos disponibles">
             <button
@@ -110,7 +120,7 @@
                       <span class="paws"></span>
                     </div>
                   </div>
-                  <span class="member-label">Mamá Arce</span>
+                  <span class="member-label">Teri Chocolate</span>
                 </div>
                 <div class="family-member" data-member="papa">
                   <div class="sylvanian" aria-hidden="true">
@@ -127,7 +137,7 @@
                       <span class="paws"></span>
                     </div>
                   </div>
-                  <span class="member-label">Papá Arce</span>
+                  <span class="member-label">Frasier Chocolate</span>
                 </div>
                 <div class="family-member" data-member="peque">
                   <div class="sylvanian" aria-hidden="true">
@@ -144,7 +154,7 @@
                       <span class="paws"></span>
                     </div>
                   </div>
-                  <span class="member-label">Peque Arce</span>
+                  <span class="member-label">Freya Chocolate</span>
                 </div>
               </div>
             </div>

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,0 +1,24 @@
+{
+  "name": "Catagotchi",
+  "short_name": "Catagotchi",
+  "description": "Cuida a tu gatito virtual y a la familia Sylvanian en un salón lleno de encanto pixel art.",
+  "start_url": "./",
+  "display": "standalone",
+  "background_color": "#ff85c5",
+  "theme_color": "#ff85c5",
+  "lang": "es",
+  "icons": [
+    {
+      "src": "icons/icon-192.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "icons/icon-512.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,71 @@
+const CACHE_NAME = 'catagotchi-v2';
+const OFFLINE_URL = './index.html';
+const ASSETS = [
+  './',
+  './index.html',
+  './styles.css',
+  './app.js',
+  './manifest.webmanifest',
+  './icons/icon-192.svg',
+  './icons/icon-512.svg',
+  './cat-purr.mp3',
+  './little-puff-purr.mp3',
+  './little-puff-purr-brr.mp3',
+  './meow-1.mp3',
+  './meow_QO6VsE6.mp3',
+  './the-end-meow-by-nekocat-just-3-second-1.mp3'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS)).then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) => Promise.all(keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key))))
+      .then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') {
+    return;
+  }
+
+  if (event.request.mode === 'navigate') {
+    event.respondWith(
+      fetch(event.request)
+        .then((response) => {
+          if (response && response.ok) {
+            const copy = response.clone();
+            caches.open(CACHE_NAME).then((cache) => cache.put(event.request, copy));
+          }
+          return response;
+        })
+        .catch(() => caches.match(event.request).then((cached) => cached || caches.match(OFFLINE_URL)))
+    );
+    return;
+  }
+
+  event.respondWith(
+    caches.match(event.request).then((cached) => {
+      if (cached) {
+        return cached;
+      }
+      return fetch(event.request)
+        .then((response) => {
+          if (!response || response.status !== 200 || response.type !== 'basic') {
+            return response;
+          }
+          const copy = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, copy));
+          return response;
+        })
+        .catch(() => caches.match(OFFLINE_URL));
+    })
+  );
+});

--- a/styles.css
+++ b/styles.css
@@ -231,6 +231,37 @@
         line-height: 1;
       }
 
+      .install-chip {
+        font-family: "Press Start 2P", system-ui;
+        font-size: 0.54rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        border: 2px solid rgba(255, 255, 255, 0.7);
+        border-radius: 999px;
+        background: rgba(255, 255, 255, 0.78);
+        color: var(--text-secondary);
+        padding: 8px 14px 6px;
+        box-shadow: 0 5px 0 rgba(255, 118, 197, 0.28);
+        cursor: pointer;
+        transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+        white-space: nowrap;
+        align-self: flex-end;
+      }
+
+      .install-chip[hidden] {
+        display: none;
+      }
+
+      .install-chip:focus-visible {
+        outline: 2px solid rgba(89, 148, 255, 0.85);
+        outline-offset: 3px;
+      }
+
+      .install-chip:active {
+        transform: translateY(2px);
+        box-shadow: 0 2px 0 rgba(255, 118, 197, 0.28);
+      }
+
       .mode-toggle {
         display: grid;
         grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -503,6 +534,8 @@
         align-items: center;
         gap: 6px;
         pointer-events: none;
+        contain: layout paint;
+        will-change: transform;
       }
 
       .family-member[data-member="mama"] {
@@ -511,9 +544,20 @@
         --fur: #f6e6d8;
         --fur-dark: #e6cbb4;
         --ear: #f8c6d6;
+        --ear-tip: #d3b192;
         --blush: rgba(255, 164, 187, 0.85);
         --outfit: #f592b6;
         --outfit-accent: #ffe5f1;
+        --mask-gradient: radial-gradient(circle at 50% 30%, rgba(204, 165, 132, 0.32) 0 56%, rgba(204, 165, 132, 0) 72%);
+        --bib-highlight: linear-gradient(180deg, rgba(255, 255, 255, 0.95), rgba(255, 235, 247, 0.55));
+        --outfit-belt: linear-gradient(90deg, rgba(255, 255, 255, 0.92), rgba(247, 192, 206, 0.68));
+        --outfit-detail:
+          radial-gradient(circle at 50% 18%, rgba(255, 255, 255, 0.92) 0 48%, rgba(255, 255, 255, 0) 52%),
+          repeating-linear-gradient(90deg, rgba(255, 183, 204, 0.38) 0 6px, rgba(255, 255, 255, 0.12) 6px 12px);
+        --outfit-lace: radial-gradient(circle at 50% 14%, rgba(255, 255, 255, 0.88) 0 46%, rgba(255, 255, 255, 0) 52%);
+        --accessory-color: #f7cbdc;
+        --outfit-detail-inset: 34% 18% 12%;
+        --outfit-detail-radius: 48% 48% 52% 52% / 58% 58% 46% 46%;
       }
 
       .family-member[data-member="papa"] {
@@ -522,9 +566,21 @@
         --fur: #f3e8d2;
         --fur-dark: #d6c2a6;
         --ear: #f3b8a6;
+        --ear-tip: #c9a078;
         --blush: rgba(255, 177, 160, 0.8);
         --outfit: #7ab4e3;
         --outfit-accent: #e4f2ff;
+        --mask-gradient: radial-gradient(circle at 50% 36%, rgba(189, 150, 115, 0.28) 0 54%, rgba(189, 150, 115, 0) 70%);
+        --bib-highlight: linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(216, 233, 255, 0.5));
+        --outfit-belt: linear-gradient(90deg, rgba(255, 255, 255, 0.88), rgba(186, 215, 246, 0.58));
+        --outfit-detail:
+          linear-gradient(180deg, rgba(255, 255, 255, 0.78), rgba(228, 242, 255, 0.36)),
+          linear-gradient(90deg, rgba(90, 138, 198, 0.55) 0 20%, rgba(255, 255, 255, 0) 20% 80%, rgba(90, 138, 198, 0.55) 80% 100%);
+        --outfit-lace: radial-gradient(circle at 50% 12%, rgba(255, 255, 255, 0.82) 0 40%, rgba(255, 255, 255, 0) 46%);
+        --accessory-color: #b4d5f2;
+        --outfit-detail-inset: 40% 24% 14%;
+        --outfit-detail-radius: 50% 50% 44% 44% / 62% 62% 46% 46%;
+        --bib-inset: 10% 24% auto;
       }
 
       .family-member[data-member="peque"] {
@@ -533,9 +589,21 @@
         --fur: #fdf0dc;
         --fur-dark: #e8cfaf;
         --ear: #ffc6d6;
+        --ear-tip: #e0b98f;
         --blush: rgba(255, 194, 189, 0.85);
         --outfit: #ffd87b;
         --outfit-accent: #fff7d1;
+        --mask-gradient: radial-gradient(circle at 50% 32%, rgba(219, 175, 126, 0.26) 0 52%, rgba(219, 175, 126, 0) 70%);
+        --bib-highlight: linear-gradient(180deg, rgba(255, 255, 255, 0.94), rgba(255, 241, 217, 0.55));
+        --outfit-belt: linear-gradient(90deg, rgba(255, 255, 255, 0.92), rgba(255, 219, 160, 0.6));
+        --outfit-detail:
+          linear-gradient(180deg, rgba(255, 255, 255, 0.85), rgba(255, 239, 211, 0.4)),
+          radial-gradient(circle at 50% 18%, rgba(255, 193, 149, 0.62) 0 26%, rgba(255, 255, 255, 0) 30%);
+        --outfit-lace: radial-gradient(circle at 50% 16%, rgba(255, 255, 255, 0.88) 0 44%, rgba(255, 255, 255, 0) 50%);
+        --accessory-color: #ffe5ab;
+        --outfit-detail-inset: 36% 22% 14%;
+        --outfit-detail-radius: 48% 48% 40% 40% / 58% 58% 44% 44%;
+        --bib-inset: 14% 24% auto;
       }
 
       .member-label {
@@ -559,6 +627,25 @@
         flex-direction: column;
         align-items: center;
         justify-content: flex-end;
+        contain: layout paint;
+        z-index: 1;
+      }
+
+      .sylvanian::after {
+        content: "";
+        position: absolute;
+        right: clamp(-6px, -1.4vw, -2px);
+        bottom: 12%;
+        width: 32%;
+        height: 34%;
+        border-radius: 50% 46% 60% 50%;
+        background:
+          radial-gradient(circle at 32% 32%, rgba(255, 255, 255, 0.88), rgba(255, 255, 255, 0) 70%),
+          radial-gradient(circle at 60% 60%, var(--fur, #f6e6d8) 0 74%, rgba(0, 0, 0, 0) 76%);
+        opacity: 0.85;
+        transform: rotate(-12deg);
+        pointer-events: none;
+        z-index: 0;
       }
 
       .sylvanian-ears {
@@ -593,19 +680,45 @@
 
       .sylvanian-ears::before,
       .sylvanian-ears::after {
-        background: linear-gradient(180deg, var(--ear, #f8c6d6) 0%, var(--fur, #f6e6d8) 78%);
+        background: linear-gradient(
+          180deg,
+          var(--ear-tip, var(--fur, #f6e6d8)) 0 28%,
+          var(--ear, #f8c6d6) 28% 62%,
+          var(--fur, #f6e6d8) 62% 100%
+        );
       }
 
       .sylvanian-head {
         position: relative;
         width: 78%;
         height: 48%;
-        background: radial-gradient(circle at 50% 36%, rgba(255, 255, 255, 0.75), transparent 62%), var(--fur, #f6e6d8);
+        background:
+          radial-gradient(circle at 50% 36%, rgba(255, 255, 255, 0.75), transparent 62%),
+          var(--mask-gradient, linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0) 100%)),
+          var(--fur, #f6e6d8);
         border-radius: 70% 70% 68% 68%;
         box-shadow: inset 0 -10px 12px rgba(0, 0, 0, 0.08);
         display: flex;
         align-items: center;
         justify-content: center;
+        overflow: visible;
+      }
+
+      .sylvanian-head::before {
+        content: "";
+        position: absolute;
+        bottom: 16%;
+        left: 50%;
+        width: 62%;
+        height: 48%;
+        transform: translateX(-50%);
+        background:
+          radial-gradient(circle at 50% 26%, rgba(255, 255, 255, 0.85) 0 32%, rgba(255, 255, 255, 0) 66%),
+          linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(255, 238, 244, 0.65));
+        border-radius: 52% 52% 48% 48%;
+        box-shadow: inset 0 -8px 10px rgba(0, 0, 0, 0.08);
+        opacity: 0.92;
+        pointer-events: none;
       }
 
       .sylvanian-head .eye {
@@ -616,6 +729,17 @@
         border-radius: 50%;
         top: 38%;
         box-shadow: 0 2px 0 rgba(0, 0, 0, 0.12);
+      }
+
+      .sylvanian-head .eye::after {
+        content: "";
+        position: absolute;
+        inset: 18% 34% auto auto;
+        width: 38%;
+        height: 38%;
+        border-radius: 50%;
+        background: radial-gradient(circle, rgba(255, 255, 255, 0.92) 0 60%, rgba(255, 255, 255, 0) 62%);
+        opacity: 0.9;
       }
 
       .sylvanian-head .eye-left {
@@ -636,6 +760,31 @@
         background: radial-gradient(circle, rgba(126, 77, 60, 0.8), rgba(58, 34, 24, 0.9));
         border-radius: 45% 45% 55% 55%;
         box-shadow: 0 2px 0 rgba(255, 255, 255, 0.45);
+      }
+
+      .sylvanian-head .nose::before,
+      .sylvanian-head .nose::after {
+        content: "";
+        position: absolute;
+        top: 50%;
+        width: clamp(32px, 12vw, 62px);
+        height: 2px;
+        background: linear-gradient(90deg, rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0));
+        opacity: 0.7;
+        box-shadow: 0 7px 0 rgba(255, 255, 255, 0.6), 0 -7px 0 rgba(255, 255, 255, 0.6);
+      }
+
+      .sylvanian-head .nose::before {
+        right: 100%;
+        margin-right: clamp(6px, 2.4vw, 12px);
+        border-radius: 4px 0 0 4px;
+      }
+
+      .sylvanian-head .nose::after {
+        left: 100%;
+        margin-left: clamp(6px, 2.4vw, 12px);
+        border-radius: 0 4px 4px 0;
+        transform: scaleX(-1);
       }
 
       .sylvanian-head .blush {
@@ -668,6 +817,32 @@
         align-items: flex-end;
         justify-content: center;
         padding-bottom: 14%;
+        overflow: visible;
+        z-index: 1;
+      }
+
+      .sylvanian-body::before {
+        content: "";
+        position: absolute;
+        inset: var(--bib-inset, 12% 20% auto);
+        height: 24%;
+        border-radius: 60% 60% 50% 50%;
+        background: var(--bib-highlight, linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(255, 255, 255, 0.45)));
+        opacity: 0.9;
+        box-shadow: inset 0 -6px 10px rgba(0, 0, 0, 0.08);
+      }
+
+      .sylvanian-body::after {
+        content: "";
+        position: absolute;
+        inset: var(--lace-inset, 26% 24% auto);
+        height: 20%;
+        border-radius: 60% 60% 44% 44%;
+        background:
+          var(--outfit-lace, radial-gradient(circle at 50% 16%, rgba(255, 255, 255, 0.82) 0 42%, rgba(255, 255, 255, 0) 48%)),
+          radial-gradient(circle at 50% 50%, var(--accessory-color, rgba(0, 0, 0, 0)) 0 36%, rgba(255, 255, 255, 0) 42%);
+        opacity: 0.85;
+        pointer-events: none;
       }
 
       .sylvanian-body .outfit {
@@ -684,8 +859,23 @@
         inset: 8% 18% auto;
         height: 24%;
         border-radius: 999px;
-        background: linear-gradient(90deg, rgba(255, 255, 255, 0.85), rgba(255, 210, 232, 0.7));
+        background: var(--outfit-belt, linear-gradient(90deg, rgba(255, 255, 255, 0.85), rgba(255, 210, 232, 0.7)));
         opacity: 0.9;
+      }
+
+      .sylvanian-body .outfit::after {
+        content: "";
+        position: absolute;
+        inset: var(--outfit-detail-inset, 38% 22% 10%);
+        border-radius: var(
+          --outfit-detail-radius,
+          40% 40% 36% 36% / 55% 55% 45% 45%
+        );
+        background: var(
+          --outfit-detail,
+          linear-gradient(180deg, rgba(255, 255, 255, 0.75), rgba(255, 255, 255, 0))
+        );
+        opacity: 0.85;
       }
 
       .sylvanian-body .paws {
@@ -1393,6 +1583,33 @@
         50% {
           transform: translateY(-6px) scaleX(var(--flip));
         }
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .cat {
+          animation: none;
+        }
+
+        .cat-wanderer {
+          transition-duration: 0.01ms !important;
+        }
+
+        .scene[data-active="family"] #familyScene[data-activity="feed"] .family-member,
+        .scene[data-active="family"] #familyScene[data-activity="nap"] .family-member {
+          animation: none !important;
+        }
+      }
+
+      body.reduce-motion .cat {
+        animation: none;
+      }
+
+      body.reduce-motion .cat-wanderer {
+        transition-duration: 0.01ms !important;
+      }
+
+      body.reduce-motion .scene[data-active="family"] #familyScene .family-member {
+        animation: none !important;
       }
 
       @media (max-width: 520px) {


### PR DESCRIPTION
## Summary
- replace the maskable PWA icons with inline SVG artwork so the install assets are text-based
- update the manifest, HTML head links, and service worker cache list to reference the new SVG resources

## Testing
- `node -e "new Function('document','window','localStorage','Audio', require('fs').readFileSync('app.js','utf8'))"`


------
https://chatgpt.com/codex/tasks/task_e_68d16c9ebd14832b9777c6c721e2548a