### PR TITLE
Adjust Lukis eyes and remove treat dash tip

### DIFF
--- a/index.html
+++ b/index.html
@@ -301,7 +301,7 @@
                   top: size * 0.38,
                   width: eyeSize,
                   height: eyeSize,
-                  background: '#86efac',
+                  background: '#d4f7d8',
                   borderRadius: '50%'
                 }}
               >
@@ -336,7 +336,7 @@
                   top: size * 0.38,
                   width: eyeSize,
                   height: eyeSize,
-                  background: '#86efac',
+                  background: '#d4f7d8',
                   borderRadius: '50%'
                 }}
               >
@@ -1538,9 +1538,6 @@
                     <span className="rounded-full bg-white/80 px-3 py-1 shadow-inner">Fallos: {misses}/{MAX_MISSES}</span>
                   </div>
                 </div>
-                <p className="mt-3 text-sm text-gray-600 leading-relaxed">
-                  Atrapa las golosinas que caen y esquiva los juguetes revoltosos. ¡Mantente en el suelo para ganar monedas!
-                </p>
                 <div ref={stageContainerRef} className="mt-5">
                   <div
                     className="relative mx-auto overflow-hidden rounded-3xl border-4 border-purple-200 bg-gradient-to-b from-sky-100 via-amber-50 to-rose-100 shadow-inner"


### PR DESCRIPTION
## Summary
- lighten Lukis' eye color to a brighter green tone across the reusable face component
- remove the instructional text from the Lukis Treat Dash game panel

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e7be830278832b8c493d842d192385