### PR TITLE
Show install shortcut button when app isn't standalone

### DIFF
--- a/index.html
+++ b/index.html
@@ -2417,7 +2417,8 @@
             }
           }, [isIosDevice, showInstallStatus]);
 
-          const shouldShowInstallButton = !isStandalone && (canInstall || isIosDevice);
+          const showQuickInstallButton = !isStandalone;
+          const shouldShowInstallButton = showQuickInstallButton && (canInstall || isIosDevice);
 
           const getStatColor = (value) => {
             if (value > 70) return 'bg-green-500';
@@ -2761,7 +2762,7 @@
                         </span>
                       </button>
                     )}
-                    {shouldShowInstallButton && (
+                    {showQuickInstallButton && (
                       <button
                         type="button"
                         onClick={handleInstallClick}


### PR DESCRIPTION
## Summary
- always show the circular install shortcut button beside the music and notification controls whenever the PWA is not already installed
- keep the full-width install banner gated to devices that can present the native prompt

## Testing
- none

------
https://chatgpt.com/codex/tasks/task_e_68e808a18cb0832b86b85a4f756e7226