### PR TITLE
Restore quick install button visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -2418,7 +2418,7 @@
           }, [isIosDevice, showInstallStatus]);
 
           const showQuickInstallButton = !isStandalone;
-          const shouldShowInstallButton = showQuickInstallButton && (canInstall || isIosDevice);
+          const shouldShowInstallButton = showQuickInstallButton;
 
           const getStatColor = (value) => {
             if (value > 70) return 'bg-green-500';


### PR DESCRIPTION
## Summary
- show the quick install button regardless of install prompt availability so users can trigger the install flow
- always render the full-width install button when not in standalone mode

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e80a6647b0832b985b61b8e94f2514