### PR TITLE
Adjust Flappy Lukis jump strength

### DIFF
--- a/index.html
+++ b/index.html
@@ -466,7 +466,7 @@
           const GRAVITY = 0.26;
           const OBSTACLE_SPEED = 1.85;
           const OBSTACLE_SPACING = 240;
-          const FLAP_STRENGTH = -10.5;
+          const FLAP_STRENGTH = -8.5;
 
           const [bird, setBird] = useState({ y: GAME_HEIGHT / 2 - BIRD_SIZE / 2, velocity: 0 });
           const [obstacles, setObstacles] = useState(() => []);


### PR DESCRIPTION
## Summary
- reduce Flappy Lukis flap strength to produce shorter jumps and make the minigame easier

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e82b8806bc832b9c23df0ce1c21d6e