### PR TITLE
Reduce stat decay and disable text selection

### DIFF
--- a/app.js
+++ b/app.js
@@ -338,9 +338,9 @@ function playMoodSound(moodKey) {
 }
 
 const baseDegradeRates = {
-  hunger: -2.4,
-  energy: -2,
-  fun: -2.2,
+  hunger: -0.6,
+  energy: -0.5,
+  fun: -0.55,
 };
 
 let degradeRates = { ...baseDegradeRates };

--- a/index.html
+++ b/index.html
@@ -19,6 +19,11 @@
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
             -webkit-font-smoothing: antialiased;
             -moz-osx-font-smoothing: grayscale;
+            user-select: none;
+            -webkit-user-select: none;
+            -ms-user-select: none;
+            -webkit-touch-callout: none;
+            touch-action: manipulation;
         }
 
         @keyframes bubbleFloat {

--- a/styles.css
+++ b/styles.css
@@ -38,6 +38,11 @@
         font-family: "Poppins", sans-serif;
         color: var(--text-primary);
         padding: 32px 18px;
+        user-select: none;
+        -webkit-user-select: none;
+        -ms-user-select: none;
+        -webkit-touch-callout: none;
+        touch-action: manipulation;
       }
 
       body::before {
@@ -166,6 +171,9 @@
         width: 118px;
         max-width: 100%;
         text-transform: uppercase;
+        user-select: text;
+        -webkit-user-select: text;
+        -ms-user-select: text;
       }
 
       .name-field input::placeholder {


### PR DESCRIPTION
## Summary
- slow down the automatic decay of hambre, energía y diversión para que bajen mucho más despacio
- desactivar la selección de texto y las opciones de copiar/traducir al pulsar repetidamente, manteniendo el campo de nombre editable

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e95649a5c0832b8479d04e74df4438