### PR TITLE
Adjust Lukis Treat Dash pacing and stat decay timing

### DIFF
--- a/app.js
+++ b/app.js
@@ -338,15 +338,15 @@ function playMoodSound(moodKey) {
 }
 
 const baseDegradeRates = {
-  hunger: -0.24,
-  energy: -0.18,
-  fun: -0.2,
+  hunger: -0.02,
+  energy: -0.015,
+  fun: -0.016666666666666666,
 };
 
 let degradeRates = { ...baseDegradeRates };
 const DAY_MODE_CHECK_INTERVAL = 60 * 1000;
 let dayModeIntervalId;
-const tickInterval = 2500;
+const tickInterval = 30000;
 let tickIntervalId = null;
 const WANDER_DELAY = 4200;
 let catWanderTimeoutId;
@@ -1009,13 +1009,13 @@ function tickProfile(profile, rates) {
   });
 
   if ((profile.hunger ?? 0) < 30) {
-    modifyStat("fun", -1.2 * delta, profile);
+    modifyStat("fun", -0.1 * delta, profile);
   }
   if ((profile.energy ?? 0) < 25) {
-    modifyStat("fun", -0.9 * delta, profile);
+    modifyStat("fun", -0.075 * delta, profile);
   }
   if ((profile.fun ?? 0) < 25) {
-    modifyStat("energy", -0.7 * delta, profile);
+    modifyStat("energy", -0.058333333333333334 * delta, profile);
   }
 
   return delta;
@@ -3056,7 +3056,7 @@ function tickProfile(profile, rates) {
             );
             dayEmoji.textContent = "🌙";
             dayLabel.textContent = "Modo noche";
-            degradeRates = { ...baseDegradeRates, energy: -1.4 };
+            degradeRates = { ...baseDegradeRates, energy: -0.11666666666666667 };
           }
         }
 

--- a/index.html
+++ b/index.html
@@ -1364,7 +1364,7 @@
 
               const updatedItems = [];
               itemsRef.current.forEach((item) => {
-                const fallSpeed = (item.speed + Math.min(scoreRef.current * 0.08, 2.6)) * delta * 3.1;
+                const fallSpeed = (item.speed + Math.min(scoreRef.current * 0.05, 1.8)) * delta * 2.2;
                 const nextY = item.y + fallSpeed;
                 if (checkCollision(playerBox.x, playerBox.y, playerBox.w, playerBox.h, item.x, nextY, ITEM_SIZE, ITEM_SIZE)) {
                   newScore += 1;
@@ -1381,7 +1381,7 @@
 
               const updatedHazards = [];
               hazardsRef.current.forEach((hazard) => {
-                const fallSpeed = (hazard.speed + Math.min(scoreRef.current * 0.07, 2.4)) * delta * 3.4;
+                const fallSpeed = (hazard.speed + Math.min(scoreRef.current * 0.05, 1.6)) * delta * 2.4;
                 const nextY = hazard.y + fallSpeed;
                 if (
                   checkCollision(


### PR DESCRIPTION
## Summary
- slow down the falling speed of treats and hazards in Lukis Cazador to soften the difficulty curve
- run the stat decay loop every 30 seconds and scale the base, night, and low-stat penalties so hunger, fun, and energy drop at the new cadence

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e95ddf1148832b8353ccaac039a8c4