### PR TITLE
Add intro video iframe to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,9 +35,31 @@
             0%, 100% { transform: rotate(-4deg) scale(1); }
             50% { transform: rotate(4deg) scale(1.05); }
         }
+
+        .intro-video-container {
+            position: relative;
+            width: 100%;
+            max-width: 960px;
+            margin: 0 auto;
+            aspect-ratio: 16 / 9;
+            background: #000;
+        }
+
+        .intro-video-container iframe {
+            position: absolute;
+            inset: 0;
+            width: 100%;
+            height: 100%;
+            border: 0;
+        }
     </style>
 </head>
 <body>
+    <section class="p-4 sm:p-6 bg-gradient-to-r from-pink-200/60 to-purple-200/60">
+        <div class="intro-video-container rounded-2xl shadow-xl overflow-hidden">
+            <iframe src="https://drive.google.com/file/d/1GKX_cPqHIzlYxvt6RB3jBPylYC-pswCN/preview" allow="autoplay" allowfullscreen title="Video de presentación"></iframe>
+        </div>
+    </section>
     <div id="root"></div>
 
     <script type="text/babel">


### PR DESCRIPTION
## Summary
- embed the provided Google Drive video at the top of the index page using an iframe
- style the video container for responsive 16:9 display with soft gradient background

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ea2e7a1124832b9a86780ad3255171